### PR TITLE
Feature/add markdown lessons

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.16",
     "react-dom": "^16.12.0",
+    "react-markdown": "^4.3.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
     "bootstrap": "^4.4.1",
+    "express": "^4.17.1",
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.16",
     "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
     "bootstrap": "^4.4.1",
-    "express": "^4.17.1",
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.16",
     "react-dom": "^16.12.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
     -->
     <title>GEMA</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans|Roboto&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/github.min.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
 </head>
@@ -41,6 +42,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
 </body>
 
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,17 @@ import FaqPage from './pages/FaqPage/index';
 import NewsPage from './pages/NewsPage/index';
 import ContactPage from './pages/ContactPage/index';
 import ContestPage from './pages/ContestPage/index';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { Switch, Route } from 'react-router'
+import LessonPage from './pages/MaterialPage/LessonPage'
 
 function App(){
     return (
         <BrowserRouter>
             <Switch>
-                <Route exact path="/About" component={AboutPage} />
-                <Route exact path="/Material" component={MaterialPage} />
+                <Route exact path="/About" component={AboutPage}/>
+                <Route exact path="/Material" component={MaterialPage}/>
+                <Route exact path="/Material/Aula/:title" component={LessonPage}/>
                 <Route exact path="/Camp" component={CampPage} />
                 <Route exact path="/FAQ" component={FaqPage} />
                 <Route exact path="/News" component={NewsPage} />

--- a/src/pages/HomePage/style.css
+++ b/src/pages/HomePage/style.css
@@ -92,3 +92,4 @@ h3 {
 .row-news {
 	margin-top: -80px;
 }
+

--- a/src/pages/MaterialPage/CodeBlock.js
+++ b/src/pages/MaterialPage/CodeBlock.js
@@ -1,0 +1,38 @@
+import React from 'react'
+const hljs = window.hljs
+
+class CodeBlock extends React.PureComponent {
+  constructor(props) {
+    super(props)
+    this.setRef = this.setRef.bind(this)
+  }
+
+  setRef(el) {
+    this.codeEl = el
+  }
+
+  componentDidMount() {
+    this.highlightCode()
+  }
+
+  componentDidUpdate() {
+    this.highlightCode()
+  }
+
+  highlightCode() {
+    hljs.highlightBlock(this.codeEl)
+  }
+
+  render() {
+    return (
+      <pre>
+        <code ref={this.setRef} className={`language-${this.props.language}`}>
+          {this.props.value}
+        </code>
+      </pre>
+    )
+  }
+}
+
+
+export default CodeBlock

--- a/src/pages/MaterialPage/LessonPage.js
+++ b/src/pages/MaterialPage/LessonPage.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Container from 'react-bootstrap/Container';
+import Header from '../../components/Header/index';
+import Footer from '../../components/Footer/index';
+import {Card} from 'react-bootstrap'
+
+import './style.css';
+
+// xs={12} sm={12} md={12} lg={12} xl={12}
+function LessonPage() {
+	return (
+		<div id="main-material">
+			<Container fluid id="cont">
+				<Row>
+					<Col>
+						<Header />
+                        <Row>
+                            <Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }}>
+                                <a id='link' class='pointer'> {'<'} Voltar </a>
+                            </Col>
+                        </Row>
+					</Col>
+				</Row>
+                <div class="grow padding-top-2">
+                    <Row>
+                        <Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }}>
+
+                            Placeholder
+                        </Col>
+                    </Row>
+                </div>
+				
+				<Row className="footer-row">
+					<Footer />
+				</Row>
+			</Container>
+		</div>
+	);
+}
+
+export default LessonPage;

--- a/src/pages/MaterialPage/LessonPage.js
+++ b/src/pages/MaterialPage/LessonPage.js
@@ -1,16 +1,33 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
 import Header from '../../components/Header/index';
 import Footer from '../../components/Footer/index';
-import {useHistory} from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
+import { useParams } from 'react-router-dom';
+import Markdown from 'react-markdown'
+import axios from 'axios'
+import CodeBlock from './CodeBlock'
 
 import './style.css';
+import './reset-this.css'
 
 // xs={12} sm={12} md={12} lg={12} xl={12}
 function LessonPage() {
     const { goBack } = useHistory()
+    const { title } = useParams()
+    const [sourceText, setSourceText] = useState("## Carregando texto...")
+    useEffect(() => {
+        const path = require(`./lessons/${title}.md`)
+        axios.get(path, {responseType: 'text'}).then(response => {
+
+            // Troca barras invertidas (que o markdown nao sabe parsear) pra <br/>
+            response.data = response.data.replace(/\\[\r\n]/g, "<br/>")
+            setSourceText(response.data)
+        })
+    }, [])
+    
 	return (
 		<div id="main-material">
 			<Container fluid id="cont">
@@ -27,8 +44,9 @@ function LessonPage() {
                 <div class="grow padding-top-2">
                     <Row>
                         <Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }}>
-
-                            Placeholder
+                            <div class='reset-this'>
+                                <Markdown source={sourceText} escapeHtml={false} renderers={{code: CodeBlock}}/>
+                            </div>
                         </Col>
                     </Row>
                 </div>

--- a/src/pages/MaterialPage/LessonPage.js
+++ b/src/pages/MaterialPage/LessonPage.js
@@ -13,6 +13,20 @@ import CodeBlock from './CodeBlock'
 import './style.css';
 import './reset-this.css'
 
+// fixing some stuff that markdown isn't smart to recognize
+function pre_processing(text) {
+    // Replace reverse slashes (which markdown can't parse) to <br/>
+    text = text.replace(/\\[\r\n]/g, "<br/>")
+    
+    // When found array[idx], markdown thinks idx is a link, even if there's no URL in parenthesis after
+    // Uses regex to replace [] with escaping \[\] characters, but only if not inside code (```)
+    text = text.split('```').map((str, idx) => {
+        if(idx%2 == 0) return str.replace(/\[(.*?)\](?!\()/g, "\\[$1\\]") // not inside code
+        return str // inside code, do nothing
+    }).join('```')
+    return text
+}
+
 // xs={12} sm={12} md={12} lg={12} xl={12}
 function LessonPage() {
     const { goBack } = useHistory()
@@ -22,8 +36,8 @@ function LessonPage() {
         const path = require(`./lessons/${title}.md`)
         axios.get(path, {responseType: 'text'}).then(response => {
 
-            // Troca barras invertidas (que o markdown nao sabe parsear) pra <br/>
-            response.data = response.data.replace(/\\[\r\n]/g, "<br/>")
+            response.data = pre_processing(response.data)
+            console.log(response.data)
             setSourceText(response.data)
         })
     }, [])

--- a/src/pages/MaterialPage/LessonPage.js
+++ b/src/pages/MaterialPage/LessonPage.js
@@ -52,7 +52,7 @@ function LessonPage() {
 					<Col>
 						<Header />
                         <Row>
-                            <Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }}>
+                            <Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }} style={{paddingTop: "2rem"}}>
                                 <a id='link' class='pointer' onClick={() => goBack()}> {'<'} Voltar </a>
                             </Col>
                         </Row>

--- a/src/pages/MaterialPage/LessonPage.js
+++ b/src/pages/MaterialPage/LessonPage.js
@@ -4,12 +4,13 @@ import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
 import Header from '../../components/Header/index';
 import Footer from '../../components/Footer/index';
-import {Card} from 'react-bootstrap'
+import {useHistory} from 'react-router-dom'
 
 import './style.css';
 
 // xs={12} sm={12} md={12} lg={12} xl={12}
 function LessonPage() {
+    const { goBack } = useHistory()
 	return (
 		<div id="main-material">
 			<Container fluid id="cont">
@@ -18,7 +19,7 @@ function LessonPage() {
 						<Header />
                         <Row>
                             <Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }}>
-                                <a id='link' class='pointer'> {'<'} Voltar </a>
+                                <a id='link' class='pointer' onClick={() => goBack()}> {'<'} Voltar </a>
                             </Col>
                         </Row>
 					</Col>

--- a/src/pages/MaterialPage/LessonPage.js
+++ b/src/pages/MaterialPage/LessonPage.js
@@ -16,8 +16,11 @@ import './reset-this.css'
 // fixing some stuff that markdown isn't smart to recognize
 function pre_processing(text) {
     // Replace reverse slashes (which markdown can't parse) to <br/>
-    text = text.replace(/\\[\r\n]/g, "<br/>")
-    
+    text = text.split('```').map((str, idx) => {
+        if(idx%2 == 0) return str.replace(/\\[\r\n]/g, "<br/>") // not inside code
+        return str // inside code, do nothing
+    }).join('```')
+
     // When found array[idx], markdown thinks idx is a link, even if there's no URL in parenthesis after
     // Uses regex to replace [] with escaping \[\] characters, but only if not inside code (```)
     text = text.split('```').map((str, idx) => {

--- a/src/pages/MaterialPage/index.js
+++ b/src/pages/MaterialPage/index.js
@@ -5,11 +5,13 @@ import Container from 'react-bootstrap/Container';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Header from '../../components/Header/index';
 import Footer from '../../components/Footer/index';
+import { useRouteMatch } from 'react-router-dom'
 
 import './style.css';
 
 // xs={12} sm={12} md={12} lg={12} xl={12}
 function MaterialPage() {
+	const { url } = useRouteMatch()
 	return (
 		<div id="main-material">
 			<Container fluid id="cont">
@@ -19,8 +21,15 @@ function MaterialPage() {
 					</Col>
 				</Row>
 				<Row>
-					<Col>
+					<Col sm={{ span: 10, offset: 1 }} xs={{ span: 10, offset: 1 }}>
 						<h1 className="title">Materiais</h1>
+						<ListGroup id='material-links'>
+							<ListGroup.Item action href={`${url}/Aula/Introducao`}> Introdução </ListGroup.Item>
+							<ListGroup.Item action href={`${url}/Aula/Programacao_C-C++`}>Programação C/C++</ListGroup.Item>
+							<ListGroup.Item action href={`${url}/Aula/Repeticao`}>Repetição</ListGroup.Item>
+							<ListGroup.Item action href={`${url}/Aula/Arrays_Strings`}>Arrays e Strings</ListGroup.Item>
+							<ListGroup.Item action href={`${url}/Aula/Funcoes_Recursao`}>Funções e Recursão</ListGroup.Item>
+						</ListGroup>
 					</Col>
 				</Row>
 				<br />

--- a/src/pages/MaterialPage/lessons/Arrays_Strings.md
+++ b/src/pages/MaterialPage/lessons/Arrays_Strings.md
@@ -1,0 +1,215 @@
+# Vetores, Matrizes e Strings
+
+# Vetores
+
+Os vetores (ou arrays) servem para armazenar várias variáveis (de mesmo tipo) de uma só vez. Podemos representar arrays da seguinte forma:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        
+        int tamanho = 10;
+        int vec[tamanho]; // tipo nome[tamanho]
+        
+        for (int i = 0; i < tamanho; i++) { //para cada posição do vetor
+            int x;
+            scanf("%d", &vec[i]); //leia um valor e armazene no vetor
+        }
+
+        for (int i = 0; i < tamanho; i++) {
+            printf("%d ", vec[i]);
+        }
+    }
+```
+
+Nesse caso, lemos 10 números inteiros e os armazenamos no array *vec*. As posições do array são representadas com valores de 0 até tamanho_var. Ou seja, um array de tamanho 10 tem posições de 0 até 9. Elas podem ser acessadas utilizando indices dentro dos colchetes, para acessar o valor que está na posição 5, por exemplo, podemos escrever vec[4].
+
+Também é possível inicializar um array com valores, da seguinte forma:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        
+        int tamanho = 5;
+        int vec[5] = {1, 2, 3, 4, 5};
+
+        for (int i = 0; i < tamanho; i++) {
+            printf("%d ", vec[i]);
+        }
+    }
+```
+
+O array acima pode ser representado da assim:
+
+| Index: | vec[0] | vec[1] | vec[2] | vec[3] | vec[4] |
+|:------:|:------:|:------:|:------:|:------:|:------:|
+| Value: |    1   |    2   |    3   |    4   |    5   |
+
+
+# Matrizes
+Uma matriz é um array 2D, isso é, um array que pode ser organizado e acessado a partir de linha e colunas. O código abaixo mostra a utilização de uma matriz:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        
+        int tamanhoLinhas = 3;
+        int tamanhoColunas = 4;
+        int mat[tamanhoLinhas][tamanhoColunas];  // tipo nome[tamanhoLinhas][tamanhoColunas]
+        
+        for (int i = 0; i < tamanhoLinhas; i++) { //para cada linha
+            for(int j = 0; j < tamanhoColunas; j++){ //para cada coluna
+                int x;
+                scanf("%d", &mat[i][j]); //leia um valor e armazene na matriz
+            }
+        }
+
+        for (int i = 0; i < tamanhoLinhas; i++) {
+            for(int j = 0; j < tamanhoColunas; j++) {
+                printf("%d ", mat[i][j]);
+            }
+            printf("\n"); //após cada linha feita a impressão de uma quebra
+        }
+    }
+```
+
+Nesse caso, lemos 12 números inteiros e os armazenamos na matriz *mat*. Cada dimensão da matriz tem posições que vão de 0 a tamaho-1. Ou seja, numa matriz 3x4, tanto as linhas são numeradas de 0 a 2 e as colunas, de 0 a 3. Assim como nos array, podemos acessar valores utilizando indices dentro dos colchetes, mas dessa vez precisaremos utilizar os dois índices, da linha e da coluna. Para acessar o valor que está na primeira linha e na primeira coluna, por exemplo, utilizaremos mat[0][0].
+
+Também é possível inicializar uma matriz com valores, da seguinte forma:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        
+        int tamanhoLinhas = 3;
+        int tamanhoColunas = 4;
+        int mat[tamanhoLinhas][tamanhoColunas] = {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}};
+
+        for (int i = 0; i < tamanhoLinhas; i++) {
+            for(int j = 0; j < tamanhoColunas; j++){
+                printf("%d ", mat[i][j]);
+            }
+            printf("\n");
+        }
+    }
+```
+
+A matriz acima pode ser representada assim:
+
+|  Index   | mat[][0] | mat[][1] | mat[][2] | mat[][3] |
+|:--------:|:--------:|:--------:|:--------:|:--------:|
+| mat[0][] |     1    |     2    |     3    |     4    |
+| mat[1][] |     5    |     6    |     7    |     8    |
+| mat[2][] |     9    |    10    |    11    |    12    |
+
+# Variáveis globais, locais e *lixo*
+
+Em todos os casos até agora, declaramos nossas variáveis dentro da função *main*. Porém, podemos também declarar variáveis fora dela. Usar variáveis globais fará mais sentido mais a frente, quando falaremos mais sobre *funções*. Por enquanto, vamos falar de apenas uma vantagem de se utilizar variáveis globais - mas, para isso, primeiro temos que entender o que é *lixo* em C/C++.
+
+Quando criamos uma variável e não atribuimos um valor à ela, o espaço da memória que é reservado pode estar com qualquer valor. Espera, não entendi nada! Ao criarmos uma variável, é alocado um espaço para ela na memória. Porém, esse espaço em memória pode já ter sido usada antes, ou seja, alguns 0s e 1s podem ter ficado "sobrando" por lá, e, mesmo quando não os queremos mais, é melhor para o computador sobrescrevê-los em vez de apagá-los. Talvez não tenha ficado tão claro, então você mesmo pode fazer uns testes: crie um programa do seguinte jeito:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        int x;
+        cout << x << endl;
+    }
+```
+
+Execute ele várias vezes, e veja os valores que x possui. Os valores diferentes mostram que a cada execução uma posição deferente da memória é utilizada e que nela havia um valor "lixo".
+
+Porém, quando criamos variáveis globais, além delas poderem ser utilizadas em qualquer lugar do código - novamente, falaremos sobre funções mais a frente - elas já se iniciam totalmente zeradas, o que muitas vezes é útil.
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+
+    int vet_global[15]; //variavel global, array de tamanho 15 de inteiros.
+
+    int main() {
+        int vet_local[15];
+        for (int i = 0; i < 15; i++) printf("%d ", vet_local[i]);
+        // no meu computador, foram printados esses valores: 0 0 8 0 1 0 -1477321288 32764 -1477321272 32764 9 0 0 0 4839111
+
+        //variavel global:
+        for (int i = 0; i < 15; i++) printf("%d ", vet_global[i]);
+        // no meu computador, foram printados esses valores: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
+    }
+```
+
+É bom ressaltar, porém, que apesar do uso de variáveis globais ser bastante útil para programação competitiva, é uma prática abominada na "programação normal". Como geralmente temos códigos grandes, com muitas variáveis e muitas funções (sério, juro que uma hora vamos falar delas), utilizar variáveis globais pode causar, por exemplo, conflitos de nomes. Então nos contests e questões pode usar e abusar dessas variáveis, mas vai com calma nos trabalhos de ICC.
+
+# Strings
+Strings são arrays de caracteres, isto é, palavras e frases. Em C não temos o tipo string, então seria preciso utilizar literalmente um vetor de caracteres ou adicionar uma biblioteca (string.h), mas em C++ já temos string como um tipo de variável.
+No código abaixo podemos ver como se faz leitura e escrita de palavras:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+
+    int main() {
+        string s;
+        
+        cin >> s;
+        cout << s;
+    }
+```
+Para ler frases ou qualquer string que contenha um espaço (" "), em geral é feita a leitura de uma linha inteira com a função getline(). Ela é utilizada da seguinte forma:
+
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        string s;
+        
+        getline(cin, s); //getline(cin, nomeDaString)
+        cout << s;
+    }
+```
+
+Uma coisa interessante é que em C++ podemos "somar" strings. Essa operação concatena strings, ou seja, se somarmos as strings a e b (a + b), adicionaremos a string b ao final de a. O exemplo abaixo mostra essa operação:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+
+    int main() {
+        string s = "Nao tenho";
+        string t = " criatividade";
+
+        s = s + t;
+        cout << t << endl; //endl = \n
+        //na tela será possível ler Nao tenho criatividade
+    }
+```
+
+Também é possível acessar uma string da mesma forma que vimos para arrays, isto é, utilizando [] para termos o valor de uma certa posição, que no caso da string é uma letra. Para fazer isso, geralmente é preciso utilizar a função size(), que retorna o tamanho da string. No código abaixo lemos uma string e imprimimos uma letra em cada linha.
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+
+    int main() {
+        string s;
+        
+        cin >> s;
+        int n = s.size();
+        for(int i = 0; i < n; i++){
+            cout << s[i] << endl;
+        }
+    }
+```
+
+Existem muitas funções e algorítmos para lidar com strings. Ao longo das aulas vamos ver outras formas de lidar com elas.

--- a/src/pages/MaterialPage/lessons/Funcoes_Recursao.md
+++ b/src/pages/MaterialPage/lessons/Funcoes_Recursao.md
@@ -1,0 +1,492 @@
+# Funções
+
+## A teoria por trás:
+
+Até agora falamos de funções várias vezes e já até vimos exemplos. Finalmente é hora de explicar o que são, como funcionam e a utilidade delas.
+
+Em um código, funções são como funções matemáticas: conjuntos de comandos que recebem valores de entrada, fazem algumas operações com esses valores e geram valores de saída (resultados). Mas pera, isso não é a mesma coisa que um programa/código? Na verdade sim. A diferença é que a função é um *trecho* de código que serve para organizá-lo e facilitar a nossa vida.
+
+Se temos, por exemplo, um conjunto de comandos que serão executados diversas vezes ao longo do progama, é muito mais fácil escrevê-lo apenas uma vez e chamar essa parte do código quando necessário. Ou se temos um código muuuuito grande e ninguém consegue entender o que está acontecendo, é possível dividí-lo em funções e fragmentá-lo para facilitar a compreensão e reduzir a chance de cometer erros.
+
+Tudo isso pode parecer um pouco abstrato, mas com alguns exemplos práticos tudo se tornará mais claro:
+
+Vamos ver agora como declará-las (criá-las).
+
+```c++
+tipo_do_retorno nome(parametros) {
+	// comandos
+	retorno
+}
+
+```
+## Os elementos básicos de uma função:
+
+### Temos quatro elementos principais que devem ser destacados:
+- **Tipo do Retorno**: uma função pode retornar (devolver) algo, como um valor, uma string, uma letra... é preciso declarar o tipo do dado que será retornado, sendo que esses tipos são os mesmos das variáveis que já vimos. Temos apenas um novo tipo: void - não retorna nada (a função só serve para executar as instruções).
+- **Nome**: é... acho que isso é auto-explicativo. Aqui vai o nome da função.
+- **Parâmetros**: pode ser que precisemos enviar para a função algum valor. É aqui que ele entra. No cálculo da área de um triângulo, por exemplo, é necessário informar as medidas da base e da altura.
+- **Retorno**: utiliza-se a palavra **return** para indicar o valor que será retornado pela função.
+
+## Alguns exemplos:
+
+```c++
+//uma função que recebe dois inteiros e retorna um double
+double media(int num1, int num2);
+
+//uma função que recebe uma letra e retorna outra letra
+char conversao_para_maiuscula(char letra);
+
+//uma função que recebe duas strings e retorna um booleano (True ou False).
+bool mesmoTamanho(string a, string b);
+```
+
+Talvez ainda não tenha ficado claro o que queremos dizer, então vamos mostrar.
+
+O código abaixo tem duas funções: main e media. Primeira coisa importante, a main é uma função. Ela não recebe nada, mas retorna um inteiro, por isso geralmente colocamos 'return 0' no final dos nossos códigos e isso significa que não ocorreram erros. A segunda função é a 'media', que recebe dois inteiros e retorna a média deles. Dentro dela temos o processamento necessário, que é o cálculo e, em seguida, o retorno do valor obtido.
+
+```c++
+double media(int num1, int num2) {
+	double m = (num1 + num2) / 2.0;
+	return m;
+}
+
+int main() {
+	int a, b;
+	cin >> a >> b;
+	int m = media(a, b);
+	
+	cout << m << "\n";
+	return 0;
+}
+```
+
+Outro exemplo. Nesse, vamos ler varias letras na main, até que a entrada seja '#". Cada letra será analizada e, se for maiúscula, será impressa.
+
+```c++
+void ehMaiuscula(char letra) {
+	if(letra >= 'A' && letra <= 'Z') { //sim, dá pra fazer essas comparações com letras
+		cout << letra << "\n";
+	}
+	return; //podemos usar o return mesmo sem nenhum valor a retornar
+}
+
+int main() {
+	char letra;
+	
+	do{
+		cin >> letra;
+		ehMaiuscula(letra);
+	} while(letra != '#')
+
+	return 0;
+}
+```
+
+Agora um último exemplo. Essa função recebe duas strings e retorna verdadeiro se elas tiverem o mesmo tamanho e falso caso contrário.
+
+```c++
+bool mesmoTamanho(string a, string b) {
+	if(a.size() == b.size()) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+int main() {
+	string a, b;
+	cin >> a >> b;
+	
+	if(mesmoTamanho(a, b))
+		cout << "As strings tem o mesmo tamanho" << "\n";
+	else
+		cout << "As strings não tem o mesmo tamanho" << "\n";
+
+	return 0;
+}
+```
+
+É importante ressaltar que quando uma variável é declarada dentro de um escopo (seja ele uma função, um for, um if...), ela só pode ser acessada dentro desse local. Então se voce quer usar uma variável que foi declarada em uma função numa outra, é preciso passá-la como *parâmetro*. 
+
+O caso abaixo, por exemplo, não funcionaria. A função printString não sabe quem é 's', então não pode fazer o acesso.
+```c++
+void printString() {
+	cout << s;
+}
+
+int main() {
+	string s;
+	cin >> s;
+	printString();
+}
+```
+
+O correto seria fazer:
+```c++
+void printString(string s) {
+	cout << s;
+}
+
+int main() {
+	string s;
+	cin >> s;
+	printString(s);
+}
+```
+
+É possível burlar isso (pelo menos para as funções), com variáveis globais, como veremos no próximo tópico.
+
+# Variáveis Globais
+Agora que já sabemos o que é função, podemos falar um pouco sobre as variáveis globais. Elas são variáveis que são declaradas fora do escopo de todas as funções. Por exemplo:
+```c++
+int a, b; // variáveis globais, fora da função main
+
+int main(){    // só um código aleatório
+	cin >> a >> b;
+	cout << a + b;
+}
+```
+
+Esse tipo de variável é bastante útil em programação competitiva, pois permite que seja feito o acesso do valor daquela variável sem ter que passá-la como parâmetro para outra função. Ou seja, qualquer função do código tem acesso ao valor dessas variáveis.
+
+Sem variável global teríamos:
+```c++
+int soma(int a, int b, int c, int d){  // todas as variáveis são passadas por parâmetro
+	return a+b+c+d;
+}
+
+int main(){    // só um código aleatório
+	int a, b, c, d;
+	cin >> a >> b >> c >> d;
+	cout << soma(a, b, c, d);
+}
+```
+
+Com variável global:
+```c++
+int a, b, c, d;
+
+int soma(){  // a função tem acesso às variáveis mesmo sem tê-las como parâmetro
+	return a+b+c+d;
+}
+
+int main(){    // só um código aleatório
+	cin >> a >> b >> c >> d;
+	cout << soma();
+}
+```
+
+Elas também são úteis pois, ao declará-las fora das funções, essas variáveis já começam zeradas, dessa forma, não é preciso inicializá-las.
+```c++
+int vetGlobal[10];  // criamos um vetor global de inteiros
+
+int main(){
+	int vetLocal[10];  // criamos um vetor local de inteiros
+	
+	for(int i = 0; i < 10; i++)   
+		cout << vetLocal[i] << " ";
+	/*No meu computador foram impressos os valores: */
+	/*27 982938 -2983 281 182 37 40 82387 748 2*/
+
+	cout << endl;
+
+	for(int i = 0; i < 10; i++) 
+		cout << vetGlobal[i] << " ";
+	/*Em todos os computadores serão impressos: */
+	/*0 0 0 0 0 0 0 0 0 0*/
+}
+```
+
+### Porém...
+Esse tipo de prática não é muito recomendada. É bastante perigoso declarar variáveis fora das funções, pois pode haver conflito de nomes, acessos indevidos e indesejados, dentre outros problemas. 
+Aqui em programação competitiva não fazemos códigos tão grandes que serão utilizados por muitas pessoas, então podem usar e abusar das variáveis globais. MAS não usem elas nos trabalhos da faculdade ou no mercado de trabalho (se usarem sem querer, a culpa não é nossa... a gente avisou).
+
+# Algumas funções úteis
+
+Como já falamos antes, no início do código nós incluímos a *biblioteca* bits/stdc++. Além de diversas outras coisas, ela contém algumas funções úteis já implementadas e prontas para serem usadas. O próprio C++ também já possui algumas funções que não existem em C. As principais são:
+
+#### Sqrt
+Essa função simplesmente retorna um double representando a raíz quadrada do número passado como parâmetro.
+```c++
+int main(){
+	int n;
+	cin >> n;
+	cout << sqrt(n) << endl;
+}
+```
+
+#### Max
+Função que retorna o máximo entre os valores passados como parâmetros (essa não existe em C). Esse valores não necessariamente precisam ser números.
+```c++
+int main(){
+	int a = 2, b = 3;
+	int maxNum = max(a, b); // maxNum vai receber o maior dos valores entre a e b
+	cout << maxNum << endl;
+	/*maxNum = 3*/
+
+	int c = 4, d = 5;
+	int maxNum2 = max({a, b, c, d}) // para comparar mais de dois valores, é preciso utilizar 
+									// as {chaves}
+	cout << maxNum2 << endl;
+	/*maxNum2 = 5*/
+
+	char e = "e", z = "z";
+	char maxChar = max(e, z); // maxChar vai receber z, pois ele é maior lexicograficamente
+	cout << maxChar << endl;
+	/*maxChar = "z"*/
+}
+```
+
+#### Min
+Essa função é similar à max, mas dessa vez retorna o mínimo entre valores.
+```c++
+int main(){
+	int a = 2, b = 3;
+	int minNum = min(a, b); // maxNum vai receber o menor dos valores entre a e b
+	cout << minNum << endl;
+	/*maxNum = 2*/
+
+	int c = 1, d = 0;
+	int minNum2 = min({a, b, c, d}) // para comparar mais de dois valores, é preciso utilizar 
+									// as {chaves}
+	cout << minNum2 << endl;
+	/*maxNum2 = 0*/
+
+	char e = "e", z = "z";
+	char minChar = min(e, z); // maxChar vai receber e, pois ele é menor lexicograficamente
+	cout << minChar << endl;
+	/*maxChar = "e"*/
+}
+```
+
+#### Abs
+A função Abs retorna o valor absoluto do parâmetro. Isto é, se o número for positivo, ele mesmo será retornado. Se for negativo, o valor positivo simétrico a ele será retornado.
+```c++
+int main(){
+	int a = 2, b = -3;
+	int positivoA = abs(a);    // positivoA = 2
+	int positivoB = abs(b);    // positivoB = abs(-3) = 3
+	cout << positivoA << " " << positivoB << endl;
+}
+```
+#### Swap
+O swap troca dois valores passados como parâmetros.
+```c++
+int main(){
+	int a = 2, b = 3;
+	swap(a, b);         //agora a = 3 e b = 2
+	cout << a << " " << b << endl;
+}
+```
+
+#### Sort
+Função de ordenação. Ela ordena os elementos num range em ordem crescente. Seus parâmetros são a posição inicial do range e a posição final +1, ou seja, um intervalo fechado no início e aberto no final (inicio, fim].
+```c++
+int main(){
+	int n;                // criando um vetor de n números entrados pelo usuário
+	cin >> n;
+	int vet[n];
+	
+	for(int i = 0; i < n; i++) cin >> vet[i];
+	
+	sort(vet, vet + n);  // ordenando o vetor, da posição inicial (que é o próprio vet) até a
+	// posição final (que é a posição inicial mais a quantidade de números, ou seja, vet + n)
+
+	for(int i = 0; i < n; i++) cin >> vet[i] >> " "; // imprimindo o vetor já ordenado
+}
+```
+
+Outra coisa legal dessa função é que podemos definir um operador para que o parâmetro de ordenação seja diferente. Por exemplo, podemos ordenar os valores em ordem decrescente. Esse operador é inserido como um terceiro parâmentro na função. Vamos ver esses exemplos abaixo:
+```c++
+bool decrescente(int a, int b) {
+	return(a > b);
+}
+
+int main(){
+	int n;                // criando um vetor de n números entrados pelo usuário
+	cin >> n;
+	int vet[n];
+
+	for(int i = 0; i < n; i++) cin >> vet[i];
+	
+	sort(vet, vet + n, decrescente);  // ordenando o vetor tendo como parâmetro o método de comparação que ta definido ali em cima ^
+}
+```
+O operador será um booleano que irá retornar um bool a partir da comparação entre os números. Nesse caso, ele vai retornar true se a for maior b e, com isso, a será inserido numa posição a frente de b no vetor.
+
+
+# Recursão
+
+Uma coisa muito louca é que uma função pode chamar ela mesma. Podemos pensar nessas funções chamadas *recursivas* como uma espécie de repetição. Em alguns casos é mais fácil implementar uma função recursiva do que um for ou um while, além disso, ela pode ser chamada com parâmetros diferentes, ou seja, a cada chamada o valor do parâmetro pode ser alterado.
+
+Vamos implementar um código de uma função recursiva que retorna a soma dos primeiros n números naturais.
+```c++
+int soma(int n) {
+	return n + soma(n-1);
+}
+
+int main(){
+	int n;
+	cin >> n;
+	cout << soma(n) << "\n";
+}
+```
+O código acima para n = 3 funciona assim:
+```
+-Main chama soma(3)
+	     soma(3) retorna (3 + soma(2))
+		             soma(2) retorna (2 + soma(1))
+				  	          soma(1) retorna (1 + soma(0))
+						    	        soma(0) retorna (0 + soma(-1))
+```
+
+Opa, algo de errado não está certo. Não queremos números negativos nessa soma. Para resolver isso, é preciso adicionar o chamado **caso base**, ou seja, um caso que diga quando a função deve parar de chamar a si mesma. O código com ela seria:
+
+```c++
+int soma(int n) {
+	if(n == 1) return 1; //caso base
+	return n + soma(n-1); //cálculo e chamada recursiva
+}
+
+int main(){
+	int n;
+	cin >> n;
+	cout << soma(n) << "\n";
+}
+```
+
+O código acima para n = 3 funciona assim:
+```
+-Main chama soma(3)
+	     soma(3) retorna (3 + soma(2))
+				 soma(2) retorna (2 + soma(1))
+		    			    	     soma(1) retorna 1
+```						  				   					
+
+Os retornos de uma função recursiva são feitos na ordem contrária à da chamada, ou seja, a última chamada é a última é ter seu valor retornado. Então, no exemplo acima, após todas as chamadas terem sido feitas, a recursão vai "voltar" fazendo de fato a operação com os valores retornados.
+```
+	-soma(1) retorna 1
+	-soma(2) retorna (2 + soma(1)) -> retorna 2+1 -> retorna 3	
+	-soma(3) retorna (3 + soma(2)) -> retorna 3+3 -> retorna 6
+```
+
+Esse tópico geralmente é um pouco confuso mesmo, então vamos mostrar outro exemplo. Nesse, vamos fazer o cálculo do fatorial de um número:
+```c++
+int fat(int n) {
+	if(n == 1) return 1; //caso base
+	return n * fat(n-1); //cálculo e chamada recursiva
+}
+
+int main(){
+	int n;
+	cin >> n;
+	cout << fat(n) << "\n";
+}
+```
+Na verdade esse exemplo é bem parecido com o anterior, a diferença é que em vez de somarmos n pela chamada recursiva, vamos multiplicá-los.
+
+Ele vai funcionar da seguite maneira:
+```
+-Main chama fat(4)
+	    fat(4) retorna (4 * fat(3))
+	    		      fat(3) retorna (3 * fat(2))
+						    fat(2) retorna (2 * fat(1))
+									fat(1) retorna 1
+```						  					   					
+Após todas as chamadas terem sido feitas, a recursão vai "voltar" fazendo de fato a operação com os valores retornados.
+```
+	-fat(1) retorna 1
+	-fat(2) retorna (2 * fat(1)) -> retorna 2 * 1 -> retorna 2
+	-fat(3) retorna (3 + fat(2)) -> retorna 3 * 2 -> retorna 6
+	-fat(4) retorna (4 * fat(3)) -> retorna 4 * 6 -> retorna 24
+```
+
+### Overview da recursão
+```c++
+int recursion(int x) {              //Função recursiva com x como parâmetro
+	if(baseCase) return value;  //Checagem do caso base, se x estiver satisfazendo esse
+					//caso, a função para de ser chamada recursivamente
+	recursion(novoX);           //Se o caso base não foi atendido, é feita a chamada
+					//recursiva com o novo valor de x
+}
+```
+
+### Continuando com exemplos
+
+A função de Fibonacci é uma função na qual o valor atual (n) é a soma dos dois valores anteriores (n-1 e n-2), ou seja, f(n) = f(n-1) + f(n-2). Como vimos antes, se não definirmos um caso base a função será infinita, então podemos dizer que f(1) = f(2) = 1. Isso quer dizer que nossa sequência vai ser 1, 1, 2, 3, 5, 8, 13, 21....
+
+```c++
+int fib(int n) {
+	if(n == 1 || n == 2) return 1; //caso base (n = 1 ou n = 2)
+	return fib(n-1) + fib(n-2);    //chamadas recursivas
+}
+
+int main(){
+	int n;
+	cin >> n;
+	cout << fib(n) << "\n";
+}
+```
+
+Ele vai funcionar da seguite maneira:
+```
+-Main chama fib(5)
+
+					fib(5) = (fib(4) + fib(3))
+						   /          \
+			fib(4) = (fib(3) + fib(2))         fib(3) = (fib(2) + fib(1))
+				/           \                          /         \
+	fib(3) = (fib(2) + fib(1))       fib(2) = 1           fib(2) = 1      fib(1) = 1
+		/           \
+	fib(2) = 1      fib(1) = 1
+
+```
+Após todas as chamadas terem sido feitas, a recursão vai "voltar" fazendo de fato a operação com os valores retornados.
+```	
+1)
+				fib(5) = (fib(4) + fib(3))
+                              		     /          \
+		   fib(4) = (fib(3) + fib(2))         fib(3) = (fib(2) + fib(1))
+			      /           \                      /          \
+      fib(3) = (fib(2) + fib(1))           1                     1          1
+	  	   /           \
+	   	   1           1
+
+
+
+2)
+				fib(5) = (fib(4) + fib(3))
+	                                 /          \
+		   fib(4) = (fib(3) + fib(2))         fib(3) = (1 + 1)
+			       /           \              
+	   	   fib(3) = (1 + 1)          1
+
+
+
+3)
+               			fib(5) = (fib(4) + fib(3))
+                   	    		     /          \
+		   fib(4) = (fib(3) + fib(2))         fib(3) = 2
+		           /           \              
+                          2             1
+
+
+4)
+                            	fib(5) = (fib(4) + fib(3))
+                               		     /          \
+			       fib(4) = (2 + 1)       fib(3) = 2
+
+
+5)
+			        fib(5) = (fib(4) + fib(3))
+                               		     /          \
+			                    3           2
+
+6)
+			        fib(5) = (3 + 2)
+
+7)			                 
+			        *fib(5) = (5)*
+```
+
+That's it, folks! Até a próxima \o/

--- a/src/pages/MaterialPage/lessons/Introducao.md
+++ b/src/pages/MaterialPage/lessons/Introducao.md
@@ -1,0 +1,145 @@
+# Introdução à Programação Competitiva
+
+<blockquote> "Dado um problema de programação já conhecido, resolva ele no menor tempo possível." </blockquote>
+
+O estudo em programação competitiva se baseia em várias técnicas e algoritmos. Além de conhecê-los, também é importante uma constante prática, para que o tempo que se gasta em cada problema seja menor.
+
+## Essências de um problema
+
+Certo, você irá resolver um problema. Para se familiarizar melhor com eles, aqui vai um resumo de como eles costumam aparecer. Normalmente, os enunciados de problemas apresentam a seguinte forma:
+
+1. Título do Problema\
+    Na maioria dos casos, é *realmente* só um título, não influenciando em nada o problema. Porém, às vezes ele nos dá uma dica de como o resolver (apresenta alguma *tag*, etc.)
+2. História do Problema\
+    Mesma coisa que em vestibular. Uma historinha que o cara criou só para o problema ter sentido - e que, assim como em matemática, o que realmente importa está dentro dela. Portanto, é sempre bom ler o enunciado para saber o que fazer.
+3. Constraints (restrições)\
+    Embora agora isso não faça muito sentido, mais pra frente vocês verão que isso importa muito. As *constraints* de determinado problema representam o intervalo que os valores de entrada podem apresentar. Isso irá restringir a complexidade do algoritmo que você desenvolver, ou o tipo de variável que você deve utilizar.
+4. Casos de Teste de Exemplo\
+    Digamos que você leu o enunciado e tem uma noção do que fazer. Então, você vê os casos de teste de exemplo. Eles terão um exemplo de entrada de valores, e logo depois a saída que o problema espera.
+5. Explicação dos Casos de Teste\
+    Em alguns problemas, também é possível que os casos de teste sejam explicados, para facilitar a compreensão do problema.
+
+## Exemplo básico
+
+Aqui vai um exemplo básico de problema:
+
+| Cremosas em Ferpa |
+| --- |
+| Tempo limite: 1s |
+
+Jaojão é um garoto sagaz. Sempre que possível, ele vai à Ferpa em busca de cremosas aos finais de semana. Agora ele quer dizer a seus amigos a quantiadade *k* de cremosas que ele avistou em sua grande terra natal em um final de semana. Seja *n* (0 < n < 100) o número de cremosas que Jaojão viu no sábado e *m* (0 < m < 100) o número de cremosas que ele viu no domingo, responda a quantidade *k* de cremosas avistadas.
+
+Entrada\
+A primeira linha contém dois inteiros *n* e *m* (a quantidade de cremosas avistadas).
+
+Saída\
+Seu programa deverá apresentar um único inteiro *k*, o total de cremosas.
+
+Exemplo
+```
+Entrada:
+3 4
+
+Saída:
+7
+```
+
+Bom, você deve ter percebido que a solução deste problema é apenas somar os dois valores de entrada. Nele, podemos perceber as situações que destaquei acima: o título do problema *(que realmente não tem nada a ajudar na solução em si)*; a história *(que tem muita coisa inútil, porém é nela que está descrito o problema)*. Nesse caso, as *constraints* são dadas também no enunciado (tanto *n* quanto *m* são valores inteiros entre 1 e 99, inclusive), isso nos ajuda a escollher os tipos de variáveis que vamos utilizar; e a restrição de tempo do problema é 1 segundo - isto é, a execução do seu problema não pode ultrapassar 1 segundo - vamos ver mais para frente como saber se seu programa será executado dentro do tempo limite.
+
+## Introdução à Programação em C++
+
+Se você já estiver familiarizado com alguma linguagem de programação *(c, python, pascal)*, não será tão difícil aprender os conceitos básicos de C++. Em C++, você pode usar tudo que se usa em *c* (posso, por exemplo, pegar um programa em C e compilá-lo em C++ sem problemas).
+
+### Formato do Código em C++
+```c++
+#include <iostream> //incluindo biblioteca que possui alguma função que eu quero
+
+int main() { //funcao principal, a primeira a ser executada em seu codigo
+    return 0; //retorno da funcao (opcional)
+}
+
+// OBS: '//' (barra barra) representa um comentario de uma linha do codigo
+// e sera ignorado na execucao do programa
+```
+
+
+
+## Introdução à Complexidade
+
+Normalmente, os computadores convencionais conseguem computar cerca de 4*10^8 comandos por segundo. E é aí que as *constraints* do problema são úteis. No caso do exemplo anterior, por exemplo, o *n* ia até no máximo 100. Ou seja, nós poderiamos fazer um *for* indo de *0* até *n* sem problemas, pois seriam executados apenas cerca de 100 comandos. Porém, se o *n* pudesse valer 10^9, isso não seria possível, pois estouraria o limite de tempo.\
+Mais para a frente iremos estudar métodos para analisar a complexidade de cada código. Porém, por enquanto, é bom ter algumas noções:
+- Se seu programa depende de *n* para o número de execuções, dizemos que ele é de ordem de alguma *f(n)* (ele é *O(f(n)*)
+- Se seu programa executa as instruções independentemente de n (por exemplo, no exemplo acima, era necessário apenas somar dois números), dizemos que ele é *constante (O(1))*
+- Um *for* de *0* a *n* apresenta complexidade *O(n)*
+- Dois *for* aninhados de *0* a *n* apresenta complexidade *O(n^2)*
+
+Essa parte de complexidade não é tão imposta no início, e será revista mais tarde, então se você não entendeu isso agora, não se preocupe: o seu "eu" do futuro se preocupará com isso.
+
+## Respostas dos Judges
+Após submeter seu código, você pode receber alguma resposta do site em que mandou:
+
+1. Accepted (AC) - sua solução estava certa e foi aceita.
+
+2. Wrong Answer (WA) - sua solução apresentou alguma saída diferente da esperada.
+
+3. Time Limit Exceed (TLE) - seu programa demorou mais do que o limite para executar.
+
+4. Memory Limit Exceed (MLE) - seu programa está usando mais memória do que deveria.
+
+5. Runtime Error (RTE) - seu programa bugou no meio da execução e travou alguma coisa (fez um acesso indevido, por exemplo).
+
+6. Presentation Error - Alguns judges apresentam esse erro, que ocorre quando a saída do problema está em um formato diferente do esperado (por exemplo, você colocou espaços ou quebras de linha a mais do que deveria).
+
+---
+
+## Referências
+
+### Sites para aprender
+É sempre bom ler sobre algoritmos em diferentes sites, para ter diferentes perspectivas sobre um tópico. Entre estes sites, recomendamos:
+
+#### Em português
+[Neps Academy](https://neps.academy/login?next=%2F)\
+[GitHub do Fakhoury](https://github.com/andrefakhoury)\
+[GitHub do Forbes](https://github.com/VictorXjoeY)\
+[GitHub do LoppA](https://github.com/LoppA)\
+[GitHub da lmoura](https://github.com/lusmoura)\
+[GitHub do Preischadt](https://github.com/thiagop-usp)\
+[GitHub do David](https://github.com/davidcairuz)
+
+#### Em inglês
+[Geeks for Geeks](https://www.geeksforgeeks.org/)\
+[HackerRank](https://www.hackerrank.com/)\
+[HackerEarth](https://www.hackerearth.com/)\
+[CP-Algorithms](https://cp-algorithms.com/)\
+Canal do [Abdul Bari](https://www.youtube.com/channel/UCZCFT11CWBi3MHNlGf019nw/) no youtube\
+Canal do [Tushar Roy](https://www.youtube.com/user/tusharroy2525) no youtube\
+[Texto do João Gui sobre deliberate practice](https://joaogui1.github.io/CP/training/)
+
+### Sites para competir
+Após ter certa noção de programação competitiva, você já pode começar a treinar e competir. Para isso, existem vários sites que te dão problemas para resolver, e alguns promovem campeonatos *(contests)* periodicamente, e dão um certo *rating* de acordo com os problemas resolvidos. Entre os melhores (*em minha opinião*) estão:
+
+[Codeforces](https://www.codeforces.com)\
+[Codechef](https://www.codechef.com)\
+[SPOJ](https://www.spoj.com)\
+[TopCoder](https://www.topcoder.com)\
+[CsAcademy](https://www.csacademy.com)\
+[UVA](https://uva.onlinejudge.org/)\
+[URI](https://www.urionlinejudge.com.br)
+
+### Livro de programação competitiva
+O livro mais utilizado por aqueles que estão aprendendo algoritmos e técnicas para maratonas de programação é o **Competitive Programming 3**, de Steven e Felix Halim. O livro conta com ótimas explicações e código em C++, além de recomendar diversos problemas para cada assunto estudado.
+
+Os problemas recomendados estão todos no [UVA](https://uva.onlinejudge.org/), um dos sites citados acima, e seu progresso na resolução de cada tópico do livro pode ser acompanhado em [uHunt](https://uhunt.onlinejudge.org/).
+
+Uma ótima forma de utilizar esse livro é combinando-o a alguns outros recursos citados aqui. Como já foi dito anteriormente, é importante tentar ter diferentes perspectivas sobre um mesmo tópico.
+
+A biblioteca do ICMC conta com apenas uma cópia, mas o livro também pode ser encontrado na internet.
+
+### Acompanhando seu progresso
+Depois de ter resolvido problemas em alguns dos online judges (sites para competir citados acima), talvez você queira ter uma visão geral do que já fez. Para isso, existem alguns sites que reúnem diversas informações, exibem gráficos, mostram números e listam seus problemas resolvidos. Eles são:
+
+[StopStalk](https://www.stopstalk.com/): Esse site reúne dados dos online judges mais famosos, mostra um heatmap de atividade, conta e lista todos os seus problemas resolvidos e ainda permite que você acompanhe seus amigos.
+
+[Codeforces Visualizer](https://cfviz.netlify.com/): Esse site faz o mesmo que o de cima, mas focando apenas no Codeforces.
+
+Os dois sites podem servir como grande fonte de motivação, então vale a pena dar uma olhada.

--- a/src/pages/MaterialPage/lessons/Programacao_C-C++.md
+++ b/src/pages/MaterialPage/lessons/Programacao_C-C++.md
@@ -1,0 +1,368 @@
+# Introdução à Linguagem C/C++
+
+Introduziremos agora à linguagem C++ (e também um pouco da linguagem C), normalmente utilizada em programação competitiva pela sua eficiência e simplicidade.
+
+Antes de começar, é bom dizer que o que fazemos em C (e que estará mais a frente) também pode ser feito em C++. Para as aplicações que utilizaremos, se simplesmente pegarmos um código em C, salvarmos com a extensão .cpp e compilarmos, tudo será executado normalmente.
+
+As partes de código precedidas de *//* são comentários. Eles são ignorados no processo de compilação e execução do código, mas facilitam o entendimento do programador e de outras pessoas que possam vir a ler o código.
+
+Recomendamos que, durante a leitura, você tente fazer os códigos ou pelo menos executar os exemplos mostrados.
+
+# Como rodar seus códigos
+
+Antes de mais nada, vamos aprender como podemos executar nossos códigos.
+
+Se você usa __Windows__, pode utilizar uma IDE para desenvolver os códigos (como CodeBlocks, DevC++...). Após escrevê-lo, basta salvar com a extensão *.cpp*. Para executar, primeiro clique no "build and run". O "build" serve para compilar o código, ou seja, transformá-lo numa linguagem que o computador consegue executar. O "run" roda o código. basicamente é isso. Cada IDE é um pouco diferente, então para informações mais específicas é só pesquisar na internet ou peguntar para um de nós =).
+
+Se usa __Linux__, pode usar uma IDE (ler parágrafo acima) ou previamente instalar o **g++**, que é um compilador de c++. Compilar é transformar o código que nós escrevemos numa linguagem que a máquina entende e sabe como executar. Para instalá-lo, primeiro é preciso abrir o terminal (utilizando as teclas ctrl+alt+t) e digitar o comando:
+```bash
+sudo apt install build-essential
+```
+Falaremos mais a frente sobre como utilizá-lo
+
+Uma vez tendo o g++, podemos escrever o código. Na hora de salvá-lo, deve-se utilizar a extensão *.cpp*.
+O terminal é aberto por padrão na pasta home do usuário. Para chegar na pasta na qual o código está salvo, precisamos navegar por ele utilizando o comando *cd*. Ele serve para entrar e sair das pastas, e é preciso especificar o caminho para chegar no arquivo desejado. Se, por exemplo, meu código tem o caminho Documents -> CompetitiveProgramming -> Aula1, o comando ficaria:
+```bash
+cd Documents/CompetitiveProgramming/Aula1      #(linux)
+```
+
+Se você entrar numa pasta sem querer, para voltar para a pasta anterior é só usar *cd ..*.
+Agora que estamos na pasta certa, podemos **compilar** o código. Para compilar, utilizamos o g++ (que instalamos previamente) e a sintaxe é a seguinte:
+```bash
+g++ nome_do_arquivo.cpp -o nome_do_executavel
+```
+
+E, por fim, para executá-lo, podemos utilizar:
+```bash
+    ./nome_do_executavel
+```
+
+# Estrutura básica em C
+
+```c
+int main() { //função principal do código, a partir da qual a execuço é iniciada
+    // aqui voce escreve seu código
+}
+```
+
+Falaremos agora sobre **variáveis**.
+
+Variáveis são tipos de dados, que podem armazenar determinados valores, de acordo com suas especificações. Os principais tipos de dados são:
+1. *int* - armazena números inteiros, no intervalo de -2^31 até +(2^31) - 1 (da ordem de -10^9 para 10^9).
+2. *char* - armazena números pequenos (-128 a 127) ou caracteres do tipo ASCII.
+3. *float* - armazena valores reais.
+4. *double* - armazena valores reais, com maior capacidade de precisão.
+
+Para declarar uma variavel, deve-se fazer o seguinte:
+
+```c
+#include <stdio.h>
+
+int main() {
+    //tipo_da_variavel nome_da_variavel
+    int x; //tipo int e nome x
+    char c;
+  
+    x = 10; //atribuição de valor à variável
+    c = 'a'; // caracteres são representados por aspas simples
+  
+    int n = 23; //também é possível atribuir um valor à variável na sua inicialização
+  
+    return 0;
+}
+```
+
+Nesse código apenas declaramos algumas variáveis e assinalamos algum valor à elas. Podemos, porém, melhorá-lo. Para isso, importaremos e utilizaremos *bibliotecas*, que são como códigos que possuem funções já implementadas, por exemplo, para a entrada e saída de dados.
+
+```c
+#include <stdio.h> //biblioteca "standart input and output"
+
+int main() {
+    printf("Hello World\n");
+    return 0;
+}
+```
+
+O código acima imprime a mensagem "Hello World", com uma quebra de linha no final (o *\n* pula a linha da saída - falaremos mais sobre as chamadas 'máscaras' do printf mais a frente). Portanto, o comando *printf()* serve para imprimir coisas na tela. Mas e se quisermos ler uma entrada (input) do usuário?
+
+```c
+#include <stdio.h>
+
+int main() {
+    int x;
+    printf("Digite um número: ");
+    scanf("%d", &x); //lendo o valor de x
+    
+    printf("O número lido foi: %d\n", x); //imprime uma frase com o valor de x, com uma quebra de linha no final
+    return 0;
+}
+```
+
+Essas funções podem parecer confusas no começo, mas elas são bastante úteis e comumente utilizadas. 
+Tanto o scanf quanto o printf funcionam com "máscaras", que dizem à função qual tipo de valor será lido/escrito. No código acima vemos o *%d* no printf e scanf. Isso representa um *sinal* à função, que saberá que deve imprimir um valor do tipo inteiro naquela parte do código. Essas são as principais máscaras:
+
+1. *%d* tipo inteiro
+2. *%f* tipo float
+3. *%lf* tipo double (long float)
+4. *%c* tipo char
+
+Também é possível ler e imprimir mais de uma variável ao mesmo tempo:
+
+```c
+#include <stdio.h>
+
+int main() {
+    int x, y; //cria uma variavel x e outra y - poderia ser em duas linhas separadas, mas podemos separar por vírgulas também.
+    scanf("%d%d", &x, &y); //lendo o valor de x e de y
+    
+    printf("Você digitou %d e %d\n", x, y);
+    return 0;
+}
+```
+
+Sem crise até aqui, certo? Vamos falar agora sobre operações que podemos fazer com variáveis. As principais são:
+1. a + b, soma a e b
+2. a - b, subtrai b de a
+3. a * b, multiplica a e b
+4. a / b, divide a por b
+5. a % b, resto da divisão de a por b
+
+```c
+int main() {
+    int x = 15, y = 2;
+    
+    int soma = x + y; //a = 15+2, ou seja, soma = 17
+    int subt = x - y; //subt = 13
+    int mult = x * y; //mult = 30
+    
+    int div = x / y; //div = 15/2, ou seja, div = 7 (hm... blz né, é inteiro...)
+    float div_real = x / y; //div_real = 7 (eita, mas agora é float... não deveria ser 7.5??)
+    
+    int resto = x % y; //resto = 15%2, ou seja, resto = 1 (pois 15 dividido por 2 temos resto 1)
+    
+    return 0;
+}
+```
+
+Simples, não? Agora, por que 15/2 é igual a 7 mesmo com a variável div_real sendo do tipo float?
+
+Estamos falando de operações com **números inteiros**. Ou seja, não podemos considerá-los números reais. Quando vamos mexer com variáveis inteiras em C ou em C++, todas as operações envolvidas com elas resultarão valores inteiros. Portanto, se quisermos que 15/2 resulte algo como 7.5, devemos converter algum número inicial (15 ou 2) para um tipo real (float ou double) ou fazer o chamado "casting", ou seja, forçar uma variável a atuar como se fosse de outro tipo. Desse jeito:
+
+```c
+int main() {
+    int x = 15;
+    double y = 2; 
+    
+    double a = x / y; //agora sim, a = 7.5
+    
+    //também seria possível fazer o casting:
+    int xx = 15, yy = 2;
+    double aa = xx / (double)yy;
+    
+    return 0;
+}
+```
+
+# Comandos Condicionais
+
+Outros comandos muito úteis são os condicionais. Isto é, fazemos linhas de código que apenas executam caso alguma condição seja satisfeita. Desse jeito:
+
+
+```c
+#include <stdio.h>
+
+int main() {
+    int x;
+    scanf("%d", &x);
+    
+    if (x == 1) {
+        printf("Você digitou o valor 1\n");
+    } else {
+        printf("Você digitou algum valor que não é 1\n");
+    }
+    
+    return 0;
+}
+```
+
+Deu pra ter uma base, certo? Caso a condição dentro dos parenteses seja satisfeita (verdadeira), serão executados os comandos que estão dentro das chaves após o *if*. Caso contrário (se a condição for falsa), poderemos adicionar também um comando *else* (senão). Essa condição é estabelecida de acordo com alguns operadores:
+
+1. a == b -> a expressão é *verdadeira* caso a seja **igual** a b (importante notar que caso queiramos fazer uma comparação, devemos utilizar '=='. Apenas um '=' significa uma atribuição, como já vimos)
+2. a != b -> a expressão é *verdadeira* caso a seja **diferente** de b
+3. a < b -> a expressão é *verdadeira* caso a seja **menor** que b
+4. a > b -> a expressão é *verdadeira* caso a seja **maior** que b
+5. a <= b -> a expressão é *verdadeira* caso a seja **menor ou igual** a b
+6. a >= b -> a expressão é *verdadeira* caso a seja **maior ou igual** a b
+
+No código abaixo vemos também um novo comando: "else if". Ele vem logo após um if e só será executado caso sua condição seja verdadeira e a condição do if anterior não tenha sido satisfeita.
+Sugerimos que você brinque um pouco com o código a seguir, testando comandos, valores e operadores diferentes.
+```c
+#include <stdio.h>
+
+int main() {
+    int a, b;
+    scanf("%d%d", &a, &b);
+    
+    if (a + b == 10) {
+        printf("A soma é 10\n");
+    } else if (a + b == 15) {
+        printf("A soma é 15\n");
+    } else {
+        printf("A soma não dá isso não\n");
+    }
+    
+    if (a * b == 32)
+        printf("A multiplicação dá 32.\n");
+    
+    return 0;
+}
+```
+
+Podemos também aprimorar as condições com as cláusulas and e or.
+Para o and (&&), o if será executado apenas se ambas as condições forem satisfeitas. Já utilizando o or (||), basta que no mínimo uma delas seja verdadeira, como pode ser observado a seguir.
+
+```c
+#include <stdio.h>
+
+int main() {
+    int x, y;
+    scanf("%d%d", &x, &y);
+    
+    if (x == 1 && y == 1) { // && é o comando de AND em C
+        printf("Tanto x quanto y são 1.\n");
+    } else if (x == 1 || y == 1) { // || é OR em C
+        printf("Algum dos dois vale 1\n");
+    } else {
+        printf("Nenhum valor vale 1.\n");
+    }
+    
+    return 0;
+}
+```
+
+## Cuidado!
+
+É comum cometer **erros lógicos** ao se lidar com condicionais. Dentre eles, tentar comparar uma variável com diversos valores da seguinte forma:
+
+```c
+if(x == 1 || 2 || 3 || 4)
+```
+Lembre-se sempre que comparações sempre são interpretadas pelo computador em pares: no caso anterior, `x` está sendo comparado com `(1 || 2 || 3 || 4)`, e essa não era a nossa intenção. Portanto, a forma correta seria:
+
+```c
+if(x == 1 || x == 2 || x == 3 || x == 4)
+```
+
+Outro erro recorrente é trocar a comparação de igualdade `==` com a atribuição `=`:
+
+```c
+if(x = 1){
+    ...
+}
+```
+
+# C++
+Bom, essa é foi introdução à programação em C. Agora, vamos ver algumas coisas que podemos fazer em C++, e que ajudarão na maratona de programação.
+
+Como foi dito no início, podemos usar em C++ os mesmos comandos que utilizamos em C. Mas também podemos fazer as coisas de um jeito um pouco diferente. Podemos, por exemplo, utilizar os comandos 'cin' e 'cout' para substituir o scanf e o printf, uma vez que, com eles, não precisamos das máscaras para os diferentes tipos de variáveis.
+
+```c++
+#include <bits/stdc++.h> //em vez de usar bibliotecas específicas, vamos usar essa aqui que tem tipo TUDO
+using namespace std; //indicaremos que estamos usando o namespace std, mas não precisa entender isso agora. Só aceita por enquanto
+
+int main() {
+    int x;
+    cin >> x; //equivalente à scanf("%d", &x);
+    
+    cout << "X vale: " << x << "\n"; //equivalente ao printf("X vale %d\n", x);
+    
+    int a;
+    double b;
+    cin >> a >> b; //lendo a e b mesmo sendo de tipos diferentes
+    if (a == 2 and b == 3.0) { //em C++, podemos também usar "and" e "or"
+        printf("a é 2 e b é 3.\n");
+    }
+    
+    return 0;
+}
+```
+
+# Overflow e o tipo *long long*
+
+Bom, como foi dito anteriormente, cada tipo de variável possui um limite para os valores que pode armazenar. Isso se dá devido a quantidade de bits e bytes que uma variável reserva na memória. Portanto, se eu digitar um valor muito grande (ou muito pequeno) em algum dos tipos citados anteriormente, acontece o chamado *overflow* - a sua variável não possui bits necessários para representar o valor inserido, e fica com um valor totalmente diferente do esperado.
+
+Esses valores dependem da arquitetura utilizada, mas, por exemplo, um tipo *int* possui, normalmente, 32 bits (4 bytes). Isso quer dizer que ele pode armazenar 2^32 números. Podemos calcular esse valor com aquele esquema de combinatória, uma vez que temos 32 "espaços" que podem ser preenchidos com 0 ou 1, a fim de representar número desejado. Se quiser saber mais sobre o sistema binário é só clicar [aqui](https://pt.wikipedia.org/wiki/Sistema_de_numera%C3%A7%C3%A3o_bin%C3%A1rio).
+
+Portanto, um *int* suporta valores até aproximadamente 2 * 10^9. Se precisarmos utilizar valores maiores, existe o tipo *long long*, que possui 64 bits (8 bytes). Portanto, ele pode suportar o dobro de valores de um int, valores, estes, que vão até aproximadamente 9.10^18, normalmente o necessário para as contas em programação competitiva. Mesmo assim, em alguns exercícios específicos, isso pode não ser o suficiente, sendo necessário o tipo BigInt - mas não precisa se preocupar com isso (ainda).
+
+```c++
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    long long x;
+    cin >> x; //lendo o valor de x - pode ser bem grande
+
+    cout << x << endl; //imprimindo o valor de x do jeito c++
+    printf("%lld\n", x); //imprimindo o valor de x do jeito C (a mascara do printf é %lld ou %I64d)
+    return 0;
+}
+```
+
+# O tipo boolean
+
+Existe também outro tipo de variável interessante que é bastante utilizado. Esse é o tipo *bool*, que tem apenas um byte, ou seja simplesmente armazena dois valores - *true* ou *false* (1 ou 0). Em C, é preciso adicionar uma biblioteca para poder utilizá-los, mas em C++ ele é um tipo nativo.
+Ele é útil, dentre outras coisas, para armazenar alguma informação que depois será usada em um comando condicional *(if e else)*. Abaixo, um exemplo (um tanto quanto inútil) de funcionamento:
+
+```c++
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    bool flag = false;
+
+    int x; 
+    cin >> x;
+    if (x == 5)
+        flag = true;
+
+    if (flag == true)
+        cout << "hmm é true hein" << endl;
+    else
+        cout << "hmm é false hein" << endl;
+}
+```
+
+# Probleminha
+
+Aqui vai um problema que aborda alguns dos principais conceitos vistos nessa aula:
+
+Um grande restaurante em São Carlos, conhecido por muitos como *podrão*, está fazendo uma formidável promoção: serão distribuídos **N** litros de óleo para o primeiro grupo de pessoas que chegar lá, com a seguinte condição: o óleo sera dividido pelo grupo, e cada pessoa do grupo deverá receber quantidades **inteiras e iguais** de óleo. Ou seja, os N litros de óleo deverão ser repartidos igualmente entre todos os integrantes do grupo. Vendo essa inigualável promoção, a famosa esportista *Limora* decide, rapidamente, formar um grupo de **K** pessoas para ir ao podrão. Porém, no meio do caminho até lá, teve uma dúvida: será que eles conseguirão ganhar a promoção?
+
+Dados a quantidade **N** de litros de óleo e **K** de pessoas no grupo, informe se Limora ganhará a promoção.
+
+**Entrada**: N e K, 2 <= N <= 100, 2 <= K <= N.
+
+**Saída**: se for possível para Limora ganhar a promoção, apresente "MENOS CINCO ANOS DE VIDA" (sem aspas). Caso contrário, informe "NÃO VAI TER HIPERTENSAO".
+
+<details><summary>Código com a solução para o problema</summary>
+
+```c++
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    int n, k; //declaracao das variaveis
+    cin >> n >> k; //leitura delas
+
+    if (n%k == 0) // se k divide n, o resto da divisao eh 0
+        cout << "MENOS CINCO ANOS DE VIDA\n"; //ganharam a promocao
+    else
+        cout << "NAO VAI TER HIPERTENSAO\n";  //nao ganharam a promocao
+
+    return 0; //fim do codigo
+}
+```
+</details>
+
+"a[1]"

--- a/src/pages/MaterialPage/lessons/Programacao_C-C++.md
+++ b/src/pages/MaterialPage/lessons/Programacao_C-C++.md
@@ -364,5 +364,3 @@ int main() {
 }
 ```
 </details>
-
-"a[1]"

--- a/src/pages/MaterialPage/lessons/Repeticao.md
+++ b/src/pages/MaterialPage/lessons/Repeticao.md
@@ -1,0 +1,165 @@
+# Laços de Repetição
+
+Nessa aula vamos aprender um pouco sobre repetição, ou seja, trechos de código que queremos executar diversas vezes. Imagine que queremos ler 5 números, e ver se algum deles vale 10. Aprendemos até aqui que isso pode ser feito da seguinte forma:
+
+```c++
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    int x1, x2, x3, x4, x5;
+    cin >> x1 >> x2 >> x3 >> x4 >> x5;
+
+    if (x1 == 10 or x2 == 10 or x3 == 10 or x4 == 10 or x5 == 10)
+        printf("Algum deles vale 10");
+    else
+        printf("Nenhum vale 10");
+}
+```
+
+Certo, isso funciona. Mas e se quisermos conferir isso para 10 números? Para 50? E para 10^5 numeros? Seria bem complicado fazer dessa forma, ne?
+
+Para isso, existem os laços de repetição. São eles, em C++, o **for**, o **while** e o **do while**.
+
+## For
+
+O comando **for** funciona da seguinte forma:
+
+```c++
+    for (int i = 0; i < 10; i = i + 1) {
+        // comandos que queremos
+    }
+```
+
+Um pouco confuso? Nem tanto. Ele sempre será mais ou menos assim:
+
+```c++
+    for (inicia_var; condicao_parada; incrementos_var) {
+        // comando
+    }
+```
+
+O primeiro **for** faz o seguinte: ele cria uma variável *i*, que começa com o valor 0. Depois, ele confere se *i* é *menor que* 10. Então, ele executa os "comandos que queremos". Após a execução, o valor de *i* é incrementado em 1, passando a valer 1. Após isso, é feito o teste novamente, *i é menor que 10?* Como *i* agora vale 1, isso é verdade, então os comandos que queremos são executados novamente. Após isso, é feito novamente o incremento de *i*, que passa a valer 2. Novamente, é feito a pergunta condicional, que ainda é verdadeira. E os comandos são executados novamente. E assim por diante, até que *i* vale 9 e é incrementado. Nesse momento, *i* passa a valer 10 e ao fazer a comparação (*i* < 10) teremos *false* como resposta e então a repetição deixa de ser executada.
+
+Representando o exemplo citado anteriormente, de se ler 5 números e checar se algum vale 10:
+
+```c++
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    bool flag = false;
+
+    for (int i = 0; i < 5; i++) { //i++ é o mesmo de i = i+1
+        int x; scanf("%d", &x);
+        if (x == 10) {
+            flag = true;
+        }
+    }
+
+    if (flag == true)
+        printf("Algum deles vale 10");
+    else
+        printf("Nenhum vale 10");
+}
+```
+
+Agora, se quisermos aumentar o limite de variáveis lidas para 10, 100 ou 1 milhão, é bem simples, pois apenas aumentamos o valor dentro da condição do for.
+
+## Algumas instruções para laços de repetição
+
+Vimos anteriormente que o comando **return** na função *main* simplesmente retorna um valor para o sistema operacional, finalizando o programa, certo? Veremos agora alguns comandos que podem ser utilizados em laços de repetição:
+
+### break;
+O laço é interrompido e para imediatamente.
+
+```c++
+    for (int i = 0; i < 5; i++) {
+        int x; cin >> x;
+        if (x == 10) 
+            break;
+    } //o for ira parar de executar quando o valor lido for igual a 10, ou quando forem lidos 5 valores.
+```
+
+### continue;
+Os comandos que estão após o *continue* não executam, porém o laço não é interrompido - o sistema finge que os comandos a serem executados acabaram, e volta no incremento das variáveis. É como se "pulassemos" uma execução.
+
+```c++
+    for (int i = 0; i < 5; i++) {
+        if (i == 2) 
+            continue;
+        cout << i << " ";
+    }
+    // output desse programa: 0 1 3 4
+```
+
+## While
+
+O *while* fará outro tipo de laço de repetição. Ele é um pouco mais simples, tendo dentro dele apenas a condição de parada. Se pensarmos na sua tradução, teremos uma noção de como ele funciona: **enquanto** uma condição é verdadeira, seu código é executado. Podemos ver a estrutura abaixo:
+
+```c++
+    while (condicao_for_verdadeira) {
+        // comandos que eu quero
+        ...
+    }
+```
+
+Abaixo, aquele mesmo exemplo de checar se temos um número 10 como entrada, agora usando while:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        bool flag = false;
+
+        int i = 0;
+        while (i < 5) {
+            int x; scanf("%d", &x);
+            if (x == 10) flag = true;
+
+            i++;
+        }
+
+        if (flag == true)
+            printf("Algum deles vale 10");
+        else
+            printf("Nenhum vale 10");
+    }
+```
+
+## Do While
+
+O *do while* é como um while, mas tem uma pequina diferença: ele sempre executará no mínimo uma vez, e verificará a condição apenas no final de seu escopo. 
+
+```c++
+    do {
+        // comandos
+    } while (condicao_existencia);    
+```
+
+Aquele mesmo exemplo:
+
+```c++
+    #include <bits/stdc++.h>
+    using namespace std;
+    
+    int main() {
+        bool flag = false;
+
+        int i = 0;
+        do {
+            int x; scanf("%d", &x);
+            if (x == 10) flag = true;
+
+            i++;
+        } while (i < 5);
+
+        if (flag == true)
+            printf("Algum deles vale 10");
+        else
+            printf("Nenhum vale 10");
+    }
+```
+
+Esses comandos são bem básicos, mas são muuuuito úteis. Recomendamos que você faça algumas alterações nos exemplos e teste em casa!

--- a/src/pages/MaterialPage/reset-this.css
+++ b/src/pages/MaterialPage/reset-this.css
@@ -423,9 +423,14 @@
 .reset-this table {
   display: table;
   border-collapse: separate;
-  border-spacing: 2px;
-  border-color: gray;
+  border: 1px solid #dfe2e5;
+  background: white;
 }
+
+.reset-this table tr:nth-child(2n) {
+    background: #f6f8fa;
+}
+
 .reset-this thead {
   display: table-header-group;
   vertical-align: middle;
@@ -454,9 +459,13 @@
   display: table-row;
   vertical-align: inherit;
   border-color: inherit;
+  border: 1px solid #c6cbd1;
 }
 .reset-this td,
 .reset-this th {
+  font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
+  border: 1px solid #dfe2e5;
+  padding: .5rem;
   display: table-cell;
   vertical-align: inherit;
 }

--- a/src/pages/MaterialPage/reset-this.css
+++ b/src/pages/MaterialPage/reset-this.css
@@ -954,7 +954,7 @@
 .reset-this plaintext,
 .reset-this listing {
   display: block;
-  font-family: monospace;
+  font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
   white-space: pre;
   margin: 1em 0;
 }

--- a/src/pages/MaterialPage/reset-this.css
+++ b/src/pages/MaterialPage/reset-this.css
@@ -137,7 +137,7 @@
     hyphens : none;
     left : auto;
     letter-spacing : normal;
-    line-height : normal;
+    line-height : 1.5rem;
     list-style : none;
     list-style-image : none;
     list-style-position : outside;
@@ -200,6 +200,7 @@
     word-spacing : normal;
     z-index : auto;
 }
+
 .reset-this html {
  display: block;
 }
@@ -1064,4 +1065,8 @@
 }
 .reset-this ol li{
     list-style-type: decimal;
+}
+
+.reset-this pre {
+    background: #F8F8F8;
 }

--- a/src/pages/MaterialPage/reset-this.css
+++ b/src/pages/MaterialPage/reset-this.css
@@ -1079,4 +1079,5 @@
 .reset-this pre {
     background: #F8F8F8;
     padding: .5rem;
+    overflow-x: auto;
 }

--- a/src/pages/MaterialPage/reset-this.css
+++ b/src/pages/MaterialPage/reset-this.css
@@ -1,0 +1,1067 @@
+.reset-this,
+.reset-this a, 
+.reset-this abbr, 
+.reset-this address, 
+.reset-this area, 
+.reset-this article, 
+.reset-this aside, 
+.reset-this div, 
+.reset-this kbd, 
+.reset-this keygen, 
+.reset-this label, 
+.reset-this legend, 
+.reset-this li, 
+.reset-this link, 
+.reset-this map, 
+.reset-this mark, 
+.reset-this menu, 
+.reset-this meta, 
+.reset-this meter, 
+.reset-this nav, 
+.reset-this noscript, 
+.reset-this object, 
+.reset-this ol, 
+.reset-this optgroup, 
+.reset-this option, 
+.reset-this output, 
+.reset-this p, 
+.reset-this param,
+.reset-this pre, 
+.reset-this progress, 
+.reset-this q, 
+.reset-this rp, 
+.reset-this rt, 
+.reset-this ruby, 
+.reset-this s, 
+.reset-this samp, 
+.reset-this script, 
+.reset-this section, 
+.reset-this select, 
+.reset-this small, 
+.reset-this source, 
+.reset-this strong,
+.reset-this style, 
+.reset-this sub, 
+.reset-this summary, 
+.reset-this sup, 
+.reset-this table, 
+.reset-this tbody, 
+.reset-this td, 
+.reset-this textarea, 
+.reset-this tfoot, 
+.reset-this th, 
+.reset-this thead, 
+.reset-this time, 
+.reset-this title, 
+.reset-this tr, 
+.reset-this track, 
+.reset-this u, 
+.reset-this ul, 
+.reset-this var, 
+.reset-this video, 
+.reset-this wbr {
+    animation : none;
+    animation-delay : 0;
+    animation-direction : normal;
+    animation-duration : 0;
+    animation-fill-mode : none;
+    animation-iteration-count : 1;
+    animation-name : none;
+    animation-play-state : running;
+    animation-timing-function : ease;
+    backface-visibility : visible;
+    background : 0;
+    background-attachment : scroll;
+    background-clip : border-box;
+    background-color : transparent;
+    background-image : none;
+    background-origin : padding-box;
+    background-position : 0 0;
+    background-position-x : 0;
+    background-position-y : 0;
+    background-repeat : repeat;
+    background-size : auto auto;
+    border : 0;
+    border-style : none;
+    border-width : medium;
+    border-bottom : 0;
+    border-bottom-left-radius : 0;
+    border-bottom-right-radius : 0;
+    border-bottom-style : none;
+    border-bottom-width : medium;
+    border-collapse : separate;
+    border-image : none;
+    border-left : 0;
+    border-left-style : none;
+    border-left-width : medium;
+    border-radius : 0;
+    border-right : 0;
+    border-right-style : none;
+    border-right-width : medium;
+    border-spacing : 0;
+    border-top : 0;
+    border-top-left-radius : 0;
+    border-top-right-radius : 0;
+    border-top-style : none;
+    border-top-width : medium;
+    bottom : auto;
+    box-shadow : none;
+    box-sizing : content-box;
+    caption-side : top;
+    clear : none;
+    clip : auto;
+    columns : auto;
+    column-count : auto;
+    column-fill : balance;
+    column-gap : normal;
+    column-rule : medium none currentColor;
+    column-rule-color : currentColor;
+    column-rule-style : none;
+    column-rule-width : none;
+    column-span : 1;
+    column-width : auto;
+    content : normal;
+    counter-increment : none;
+    counter-reset : none;
+    cursor : auto;
+    direction : ltr;
+    display : inline;
+    empty-cells : show;
+    float : none;
+    font : normal;
+    font-size : medium;
+    font-style : normal;
+    font-variant : normal;
+    font-weight : normal;
+    height : auto;
+    hyphens : none;
+    left : auto;
+    letter-spacing : normal;
+    line-height : normal;
+    list-style : none;
+    list-style-image : none;
+    list-style-position : outside;
+    list-style-type : disc;
+    margin : 0;
+    margin-bottom : 0;
+    margin-left : 0;
+    margin-right : 0;
+    margin-top : 0;
+    max-height : none;
+    max-width : none;
+    min-height : 0;
+    min-width : 0;
+    opacity : 1;
+    orphans : 0;
+    outline : 0;
+    outline-color : invert;
+    outline-style : none;
+    outline-width : medium;
+    overflow : visible;
+    overflow-x : visible;
+    overflow-y : visible;
+    padding : 0;
+    padding-bottom : 0;
+    padding-left : 0;
+    padding-right : 0;
+    padding-top : 0;
+    page-break-after : auto;
+    page-break-before : auto;
+    page-break-inside : auto;
+    perspective : none;
+    perspective-origin : 50% 50%;
+    position : static;
+    /* May need to alter quotes for different locales (e.g fr) */
+    quotes : '\201C' '\201D' '\2018' '\2019';
+    right : auto;
+    tab-size : 8;
+    table-layout : auto;
+    text-align-last : auto;
+    text-decoration : none;
+    text-decoration-line : none;
+    text-decoration-style : solid;
+    text-indent : 0;
+    text-shadow : none;
+    text-transform : none;
+    top : auto;
+    transform : none;
+    transform-style : flat;
+    transition : none;
+    transition-delay : 0s;
+    transition-duration : 0s;
+    transition-property : none;
+    transition-timing-function : ease;
+    unicode-bidi : normal;
+    vertical-align : baseline;
+    visibility : visible;
+    white-space : normal;
+    widows : 0;
+    width : auto;
+    word-spacing : normal;
+    z-index : auto;
+}
+.reset-this html {
+ display: block;
+}
+.reset-this head,
+.reset-this link,
+.reset-this meta,
+.reset-this script,
+.reset-this style,
+.reset-this title {
+  display: none;
+}
+.reset-this body {
+  display: block;
+  margin: 8px;
+}
+.reset-this p {
+  display: block;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 1em 0;
+}
+.reset-this address,
+.reset-this article,
+.reset-this aside,
+.reset-this div,
+.reset-this footer,
+.reset-this header,
+.reset-this hgroup,
+.reset-this layer,
+.reset-this main,
+.reset-this nav,
+.reset-this section {
+  display: block;
+}
+.reset-this marquee {
+  display: inline-block;
+  overflow: -webkit-marquee;
+}
+.reset-this blockquote {
+  display: block;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 40px;
+  margin-right: 40px;
+  margin: 1em 40px;
+}
+.reset-this figcaption {
+  display: block;
+}
+.reset-this figure {
+  display: block;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 40px;
+  margin-right: 40px;
+  margin: 1em 40px;
+}
+.reset-this q {
+  display: inline;
+}
+.reset-this q::before {
+  content: open-quote;
+}
+.reset-this q::after {
+  content: close-quote;
+}
+.reset-this center {
+  display: block;
+  text-align: -webkit-center;
+}
+.reset-this hr {
+  display: block;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  margin-left: auto;
+  margin-right: auto;
+  margin: 0.5em auto;
+  border-style: inset;
+  border-width: 1px;
+}
+.reset-this video {
+  object-fit: contain;
+}
+.reset-this h1 {
+  display: block;
+  font-size: 2em;
+  margin-top: 0.67em;
+  margin-bottom: 0.67em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 0.67em 0;
+  font-weight: bold;
+}
+.reset-this :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) h1 {
+  font-size: 1.5em;
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  margin: 0.83em 0;
+}
+.reset-this :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) h1 {
+  font-size: 1.17em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin: 1em 0;
+}
+.reset-this :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) h1 {
+  font-size: 1.00em;
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  margin: 1.33em 0;
+}
+.reset-this :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) h1 {
+  font-size: .83em;
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  margin: 1.67em 0;
+}
+.reset-this :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) :matches(article,
+.reset-this aside,
+.reset-this nav,
+.reset-this section) h1 {
+  font-size: .67em;
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  margin: 2.33em 0;
+}
+.reset-this h2 {
+  display: block;
+  font-size: 1.5em;
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 0.83em 0;
+  font-weight: bold;
+}
+.reset-this h3 {
+  display: block;
+  font-size: 1.17em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 1em 0;
+  font-weight: bold;
+}
+.reset-this h4 {
+  display: block;
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 1.33em 0;
+  font-weight: bold;
+}
+.reset-this h5 {
+  display: block;
+  font-size: .83em;
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 1.67em 0;
+  font-weight: bold;
+}
+.reset-this h6 {
+  display: block;
+  font-size: .67em;
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 2.33em 0;
+  font-weight: bold;
+}
+.reset-this table {
+  display: table;
+  border-collapse: separate;
+  border-spacing: 2px;
+  border-color: gray;
+}
+.reset-this thead {
+  display: table-header-group;
+  vertical-align: middle;
+  border-color: inherit;
+}
+.reset-this tbody {
+  display: table-row-group;
+  vertical-align: middle;
+  border-color: inherit;
+}
+.reset-this tfoot {
+  display: table-footer-group;
+  vertical-align: middle;
+  border-color: inherit;
+}
+.reset-this table > tr {
+  vertical-align: middle;
+}
+.reset-this col {
+  display: table-column;
+}
+.reset-this colgroup {
+  display: table-column-group;
+}
+.reset-this tr {
+  display: table-row;
+  vertical-align: inherit;
+  border-color: inherit;
+}
+.reset-this td,
+.reset-this th {
+  display: table-cell;
+  vertical-align: inherit;
+}
+.reset-this th {
+  font-weight: bold;
+}
+.reset-this caption {
+  display: table-caption;
+  text-align: -webkit-center;
+}
+.reset-this ul,
+.reset-this menu,
+.reset-this dir {
+  display: block;
+  list-style-type: disc;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 1em 0;
+  padding-left: 40px;
+  padding: 40px;
+}
+.reset-this ol {
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  margin: 1em 0;
+  padding-left: 40px;
+  padding-left: 40px;
+}
+.reset-this li {
+  display: list-item;
+  text-align: -webkit-match-parent;
+}
+.reset-this ul ul,
+.reset-this ol ul {
+  list-style-type: circle;
+}
+.reset-this ol ol ul,
+.reset-this ol ul ul,
+.reset-this ul ol ul,
+.reset-this ul ul ul {
+  list-style-type: square;
+}
+.reset-this dd {
+  display: block;
+  margin-left: 40px;
+  margin-left: 40px;
+}
+.reset-this dl {
+  display: block;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+}
+.reset-this dt {
+  display: block;
+}
+.reset-this ol ul,
+.reset-this ul ol,
+.reset-this ul ul,
+.reset-this ol ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+.reset-this form {
+  display: block;
+  margin-top: 0em;
+}
+.reset-this label {
+  cursor: default;
+}
+.reset-this legend {
+  display: block;
+  padding-left: 2px;
+  padding-right: 2px;
+  padding-left: 2px;
+  padding-right: 2px;
+  border: none;
+}
+.reset-this fieldset {
+  display: block;
+  margin-left: 2px;
+  margin-right: 2px;
+  -webkit-padding-before: 0.35em;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  -webkit-padding-after: 0.625em;
+  border: 2px groove ThreeDFace;
+  min-width: -webkit-min-content;
+}
+.reset-this button {
+  -webkit-appearance: button;
+}
+.reset-this input,
+.reset-this textarea,
+.reset-this keygen,
+.reset-this select,
+.reset-this button,
+.reset-this isindex,
+.reset-this meter,
+.reset-this progress {
+  -webkit-writing-mode: horizontal-tb !important;
+}
+.reset-this input,
+.reset-this textarea,
+.reset-this keygen,
+.reset-this select,
+.reset-this button,
+.reset-this isindex {
+  margin: 0em;
+  color: initial;
+  letter-spacing: normal;
+  word-spacing: normal;
+  line-height: normal;
+  text-transform: none;
+  text-indent: 0;
+  text-shadow: none;
+  display: inline-block;
+  text-align: start;
+}
+.reset-this input[type="hidden"] {
+  display: none;
+}
+.reset-this input,
+.reset-this input:matches([type="password"],
+.reset-this [type="search"]),
+.reset-this isindex {
+  -webkit-appearance: textfield;
+  background-color: white;
+  border: 2px inset;
+  padding: 1px;
+  -webkit-rtl-ordering: logical;
+  -webkit-user-select: text;
+  cursor: auto;
+}
+.reset-this input[type="search"] {
+  -webkit-appearance: searchfield;
+  box-sizing: border-box;
+}
+.reset-this input::-webkit-textfield-decoration-container {
+  display: flex;
+  align-items: center;
+  content: none !important;
+}
+.reset-this input[type="search"]::-webkit-textfield-decoration-container {
+  direction: ltr;
+}
+.reset-this input::-webkit-clear-button {
+  -webkit-appearance: searchfield-cancel-button;
+  display: inline-block;
+  flex: none;
+  margin-left: 2px;
+}
+.reset-this input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: searchfield-cancel-button;
+  display: block;
+  flex: none;
+  align-self: flex-start;
+  margin: auto 0;
+}
+.reset-this input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: searchfield-decoration;
+  display: block;
+  flex: none;
+  align-self: flex-start;
+  margin: auto 0;
+}
+.reset-this input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance: searchfield-results-decoration;
+  display: block;
+  flex: none;
+  align-self: flex-start;
+  margin: auto 0;
+}
+.reset-this input[type="search"]::-webkit-search-results-button {
+  -webkit-appearance: searchfield-results-button;
+  display: block;
+  flex: none;
+}
+.reset-this input::-webkit-inner-spin-button {
+  -webkit-appearance: inner-spin-button;
+  display: block;
+  position: relative;
+  cursor: default;
+  height: 1.5em;
+  vertical-align: top;
+  flex: none;
+  -webkit-user-select: none;
+}
+.reset-this input::-webkit-auto-fill-button {
+  -webkit-mask-image: -webkit-image-set(url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAMCAYAAAC9QufkAAAAAXNSR0IB2cksfwAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAADyWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgICAgICAgICB4bWxuczpleGlmPSJodHRwOi8vbnMuYWRvYmUuY29tL2V4aWYvMS4wLyI+CiAgICAgICAgIDx4bXA6TW9kaWZ5RGF0ZT4yMDE1LTA0LTAzVDE2OjA2OjI1PC94bXA6TW9kaWZ5RGF0ZT4KICAgICAgICAgPHhtcDpDcmVhdG9yVG9vbD5BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFjaW50b3NoKTwveG1wOkNyZWF0b3JUb29sPgogICAgICAgICA8eG1wOkNyZWF0ZURhdGU+MjAxNS0wNC0wM1QxNjowMzoxNjwveG1wOkNyZWF0ZURhdGU+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjcyPC90aWZmOllSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpSZXNvbHV0aW9uVW5pdD4yPC90aWZmOlJlc29sdXRpb25Vbml0PgogICAgICAgICA8dGlmZjpYUmVzb2x1dGlvbj43MjwvdGlmZjpYUmVzb2x1dGlvbj4KICAgICAgICAgPGV4aWY6Q29sb3JTcGFjZT4xPC9leGlmOkNvbG9yU3BhY2U+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4xNTwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWURpbWVuc2lvbj4xMjwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgoz37ZdAAAA5ElEQVQoFY2RsQ5BQRBFd9EgEYXv8QlaEqVGpfUPao3oKXyEQiJI1ERESaGmwnPu2k2QJ2uS82Z2du7s7jyTJInBWnCABeygoXwM6kwN1GELFo7wgOo/4gmFEovzWzyMiTMUlyFYJQT4wlucGko8T90xZv0j/5EusVpCuLr8FPK6NraHPmT8Oks8gI2bKEEOZhAauEJf3PX5Eb4ImpEG2gni0NWJvwdFYRvuoIHeoOUa++56+wpSxb6myf4J6qG5VWCt1ckPvHsksf531HSiDJ1VV9n15eJfJ+YkvWcMF+jFZa+KJ554xIc+jempAAAAAElFTkSuQmCC") 1x,url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAYCAYAAADtaU2/AAAAAXNSR0IB2cksfwAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAADyWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iCiAgICAgICAgICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgICAgICAgICB4bWxuczpleGlmPSJodHRwOi8vbnMuYWRvYmUuY29tL2V4aWYvMS4wLyI+CiAgICAgICAgIDx4bXA6TW9kaWZ5RGF0ZT4yMDE1LTA0LTAzVDE2OjA2OjIxPC94bXA6TW9kaWZ5RGF0ZT4KICAgICAgICAgPHhtcDpDcmVhdG9yVG9vbD5BZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFjaW50b3NoKTwveG1wOkNyZWF0b3JUb29sPgogICAgICAgICA8eG1wOkNyZWF0ZURhdGU+MjAxNS0wNC0wM1QxNjowMzoyNTwveG1wOkNyZWF0ZURhdGU+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDx0aWZmOllSZXNvbHV0aW9uPjcyPC90aWZmOllSZXNvbHV0aW9uPgogICAgICAgICA8dGlmZjpSZXNvbHV0aW9uVW5pdD4yPC90aWZmOlJlc29sdXRpb25Vbml0PgogICAgICAgICA8dGlmZjpYUmVzb2x1dGlvbj43MjwvdGlmZjpYUmVzb2x1dGlvbj4KICAgICAgICAgPGV4aWY6Q29sb3JTcGFjZT4xPC9leGlmOkNvbG9yU3BhY2U+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4zMDwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWURpbWVuc2lvbj4yNDwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpGMDB3AAAB8UlEQVRIDbVWO07DQBS0QSJUNJQcAloOQMEZ6InSUMEBkFJEQihQkQKJklQUlFBQQoH4SHAKJDokAgIz4+wLs5u15RjypOF9dvaN197dkCS/NodwC7gG3hxuXI1jUcuyLKkDa7aE4B7IHM7hCcs5Rs6Y1RHlHBpXo6JXeXX45xLOxB8QN2QsD+sKz2B2E1iRhqnEsxIvI96U/M8hv6mtyjxXehGpk+tZ3RVzdQOgcPN4KkPuvNbse2mtSsxXPYl9TkIu41L4rowQjD0Fee2UwqcTzA65/TRNB0CzSg/ygHegT34D4FGxjVXkHx0XbmQfiIzfKtto4LWEy3m58XLQs2zNzPPByAltGwXj0EfFUecbUd4O8pFxZ98CSrC4bNfvypxvxBu6cubAl3DaRSfBxNRjXtxckw5GjU+RXJweUNGOPRTqnrWRWQP1HkkTaRSK98CLioYr5vV4BqigxarlxSbsmu0XzO8qLxRmw/WCiRyLmjYEgTfhEWAPTM88VV4ozDP9HEyyBijHLdKQ4l2AR+YAGBMNhcFJVgETU8+xqIXCVXNtxm9cdJyU58VVhUKe/khwB+55XaeYqDC/zdoUtbzWFDPj7fQCLFjB+Vf4xaA2SvkK65iumLvwJNLkOFL79xJXfQhwlQTjsnu61r+2fEs/b4ZbzrEPMzEAAAAASUVORK5CYII=") 2x);
+  -webkit-mask-size: 15px 12px;
+  width: 15px;
+  height: 12px;
+  margin-left: 3px;
+  margin-right: 2px;
+  background-color: black;
+  flex: none;
+  -webkit-user-select: none;
+}
+.reset-this input::-webkit-auto-fill-button:hover {
+  background-color: #007aff;
+}
+.reset-this input::-webkit-auto-fill-button:active {
+  background-color: #003cdb;
+}
+.reset-this input::-webkit-caps-lock-indicator {
+  -webkit-appearance: caps-lock-indicator;
+  content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="17" height="17"><path fill="black" fill-opacity="0.4" d="M12.5 0.5A 4 4 0 0 1 16.5 4.5L 16.5 12.5A 4 4 0 0 1 12.5 16.5L 4.5 16.5A 4 4 0 0 1 0.5 12.5L 0.5 4.5A 4 4 0 0 1 4.5 0.5L 12.5 0.5M 8.5 2L 4 7L 6.25 7L 6.25 10.25L 10.75 10.25L 10.75 7L 13 7L 8.5 2M 10.75 12L 6.25 12L 6.25 14.25L 10.75 14.25L 10.75 12"/></svg>');
+  align-self: stretch;
+  flex: none;
+  -webkit-user-select: none;
+}
+.reset-this keygen,
+.reset-this select {
+  border-radius: 5px;
+}
+.reset-this keygen::-webkit-keygen-select {
+  margin: 0px;
+}
+.reset-this textarea {
+  -webkit-appearance: textarea;
+  -webkit-nbsp-mode: space;
+  -webkit-line-break: after-white-space;
+  flex-direction: column;
+  resize: auto;
+  cursor: auto;
+  padding: 2px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.reset-this ::-webkit-input-placeholder {
+  -webkit-text-security: none;
+  color: darkGray;
+  pointer-events: none !important;
+}
+.reset-this input::-webkit-input-placeholder,
+.reset-this isindex::-webkit-input-placeholder {
+  white-space: pre;
+  word-wrap: normal;
+  overflow: hidden;
+}
+.reset-this input[type="password"] {
+  -webkit-text-security: disc !important;
+}
+.reset-this input:matches([type="hidden"],
+.reset-this [type="image"],
+.reset-this [type="file"]) {
+  -webkit-appearance: initial;
+  padding: initial;
+  background-color: initial;
+  border: initial;
+}
+.reset-this input[type="file"] {
+  align-items: baseline;
+  color: inherit;
+  text-align: start !important;
+}
+.reset-this input:-webkit-autofill {
+  background-color: #FAFFBD !important;
+  background-image: none !important;
+  color: #000000 !important;
+}
+.reset-this input:matches([type="radio"],
+.reset-this [type="checkbox"]) {
+  margin: 3px 2px;
+  padding: initial;
+  background-color: initial;
+  border: initial;
+}
+.reset-this input:matches([type="button"],
+.reset-this [type="submit"],
+.reset-this [type="reset"]) {
+  -webkit-appearance: push-button;
+  white-space: pre;
+}
+.reset-this input[type="file"]::-webkit-file-upload-button {
+  -webkit-appearance: push-button;
+  white-space: nowrap;
+  margin: 0;
+  font-size: inherit;
+}
+.reset-this input:matches([type="button"],
+.reset-this [type="submit"],
+.reset-this [type="reset"]),
+.reset-this input[type="file"]::-webkit-file-upload-button,
+.reset-this button {
+  align-items: flex-start;
+  text-align: center;
+  cursor: default;
+  color: ButtonText;
+  padding: 0 1.0em;
+  border: 1px solid #4c4c4c;
+  background-color: rgba(255,255,255,0.01);
+  font: 11px Helvetica;
+  box-sizing: border-box;
+}
+.reset-this input:matches([type="button"],
+.reset-this [type="submit"],
+.reset-this [type="reset"]):active,
+.reset-this input[type="file"]::-webkit-file-upload-button:active,
+.reset-this button:active {
+  color: ActiveButtonText;
+}
+.reset-this input[type="range"] {
+  -webkit-appearance: slider-horizontal;
+  padding: initial;
+  border: initial;
+  margin: 2px;
+  color: #909090;
+}
+.reset-this input[type="range"]::-webkit-slider-container,
+.reset-this input[type="range"]::-webkit-media-slider-container {
+  flex: 1;
+  box-sizing: border-box;
+  display: flex;
+  align-contents: center;
+}
+.reset-this input[type="range"]::-webkit-slider-runnable-track {
+  flex: 1;
+  align-self: center;
+  box-sizing: border-box;
+  display: block;
+}
+.reset-this input[type="range"]::-webkit-slider-thumb,
+.reset-this input[type="range"]::-webkit-media-slider-thumb {
+  -webkit-appearance: sliderthumb-horizontal;
+  box-sizing: border-box;
+  display: block;
+}
+.reset-this input:matches([type="button"],
+.reset-this [type="submit"],
+.reset-this [type="reset"]):disabled,
+.reset-this input[type="file"]:disabled::-webkit-file-upload-button,
+.reset-this button:disabled,
+.reset-this select:disabled,
+.reset-this keygen:disabled,
+.reset-this optgroup:disabled,
+.reset-this option:disabled,
+.reset-this select[disabled]>option {
+  color: GrayText;
+}
+.reset-this area,
+.reset-this param {
+  display: none;
+}
+.reset-this input[type="checkbox"] {
+  -webkit-appearance: checkbox;
+  border-radius: 5px;
+  width: 16px;
+  height: 16px;
+  padding: 0px;
+  background-color: rgba(255,255,255,0.01);
+}
+.reset-this select {
+  box-sizing: border-box;
+  -webkit-appearance: menulist;
+  border: 1px solid;
+  color: black;
+  background-color: white;
+  align-items: center;
+  white-space: pre;
+  -webkit-rtl-ordering: logical;
+  cursor: default;
+}
+.reset-this optgroup {
+  font-weight: bolder;
+}
+.reset-this option {
+  font-weight: normal;
+}
+.reset-this output {
+  display: inline;
+}
+.reset-this ::-webkit-validation-bubble {
+  display: inline-block;
+  z-index: 2147483647;
+  position: absolute;
+  opacity: 0.95;
+  line-height: 0;
+  margin: 0;
+  -webkit-text-security: none;
+  transition: opacity 05.5s ease;
+}
+.reset-this ::-webkit-validation-bubble-message {
+  display: flex;
+  position: relative;
+  top: -4px;
+  font: message-box;
+  color: black;
+  min-width: 50px;
+  max-width: 200px;
+  border: solid 2px #400;
+  background: -webkit-gradient(linear,left top,left bottom,from(#f8ecec),to(#e8cccc));
+  padding: 8px;
+  border-radius: 8px;
+  -webkit-box-shadow: 4px 4px 4px rgba(100,100,100,0.6), inset -2px -2px 1px #d0c4c4, inset 2px 2px 1px white;
+  line-height: normal;
+  white-space: normal;
+  z-index: 2147483644;
+}
+.reset-this ::-webkit-validation-bubble-text-block {
+  flex: 1;
+}
+.reset-this ::-webkit-validation-bubble-heading {
+  font-weight: bold;
+}
+.reset-this ::-webkit-validation-bubble-arrow {
+  display: inline-block;
+  position: relative;
+  left: 32px;
+  width: 16px;
+  height: 16px;
+  background-color: #f8ecec;
+  border-width: 2px 0 0 2px;
+  border-style: solid;
+  border-color: #400;
+  box-shadow: inset 2px 2px 1px white;
+  -webkit-transform-origin: 0 0;
+  transform: rotate(45deg);
+  z-index: 2147483645;
+}
+.reset-this ::-webkit-validation-bubble-arrow-clipper {
+  display: block;
+  overflow: hidden;
+  height: 16px;
+}
+.reset-this progress {
+  -webkit-appearance: progress-bar;
+  box-sizing: border-box;
+  display: inline-block;
+  height: 1em;
+  width: 10em;
+  vertical-align: -0.2em;
+}
+.reset-this progress::-webkit-progress-inner-element {
+  -webkit-appearance: inherit;
+  box-sizing: inherit;
+  height: 100%;
+  width: 100%;
+}
+.reset-this progress::-webkit-progress-bar {
+  background-color: gray;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}
+.reset-this progress::-webkit-progress-value {
+  background-color: green;
+  height: 100%;
+  width: 50%;
+  box-sizing: border-box;
+}
+.reset-this u,
+.reset-this ins {
+  text-decoration: underline;
+}
+.reset-this strong,
+.reset-this b {
+  font-weight: bold;
+}
+.reset-this i,
+.reset-this cite,
+.reset-this em,
+.reset-this var,
+.reset-this address,
+.reset-this dfn {
+  font-style: italic;
+}
+.reset-this tt,
+.reset-this code,
+.reset-this kbd,
+.reset-this samp {
+  font-family: monospace;
+}
+.reset-this pre,
+.reset-this xmp,
+.reset-this plaintext,
+.reset-this listing {
+  display: block;
+  font-family: monospace;
+  white-space: pre;
+  margin: 1em 0;
+}
+.reset-this mark {
+  background-color: yellow;
+  color: black;
+}
+.reset-this big {
+  font-size: larger;
+}
+.reset-this small {
+  font-size: smaller;
+}
+.reset-this s,
+.reset-this strike,
+.reset-this del {
+  text-decoration: line-through;
+}
+.reset-this sub {
+  vertical-align: sub;
+  font-size: smaller;
+}
+.reset-this sup {
+  vertical-align: super;
+  font-size: smaller;
+}
+.reset-this nobr {
+  white-space: nowrap;
+}
+.reset-this :focus {
+  outline: auto;
+}
+.reset-this html:focus,
+.reset-this body:focus,
+.reset-this input[readonly]:focus,
+.reset-this applet:focus,
+.reset-this embed:focus,
+.reset-this iframe:focus,
+.reset-this object:focus {
+  outline: none;
+}
+.reset-this input:matches([type="button"],
+.reset-this [type="checkbox"],
+.reset-this [type="file"],
+.reset-this [type="hidden"],
+.reset-this [type="image"],
+.reset-this [type="radio"],
+.reset-this [type="reset"],
+.reset-this [type="search"],
+.reset-this [type="submit"]):focus,
+.reset-this input[type="file"]:focus::-webkit-file-upload-button {
+  outline-offset: 0;
+}
+.reset-this a:any-link {
+  cursor: auto;
+  color: #0000EE;
+  color: -webkit-link;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.reset-this a:any-link:active {
+  color: -webkit-activelink;
+}
+
+.reset-this a:hover {
+    outline-style: none; -moz-outline-style:none;
+    border: none;
+    outline: 0;
+}
+.reset-this ruby,
+.reset-this rt {
+  text-indent: 0;
+}
+.reset-this rt {
+  line-height: normal;
+  -webkit-text-emphasis: none;
+}
+.reset-this ruby > rt {
+  display: block;
+  font-size: -webkit-ruby-text;
+  text-align: start;
+}
+.reset-this ruby > rp {
+  display: none;
+}
+.reset-this noframes {
+  display: none;
+}
+.reset-this frameset,
+.reset-this frame {
+  display: block;
+}
+.reset-this frameset {
+  border-color: inherit;
+}
+.reset-this iframe {
+  border: 2px inset;
+}
+.reset-this details {
+  display: block;
+}
+.reset-this summary {
+  display: block;
+}
+.reset-this summary::-webkit-details-marker {
+  display: inline-block;
+  width: 0.66em;
+  height: 0.66em;
+  margin-right: 0.4em;
+}
+.reset-this bdi,
+.reset-this output {
+  unicode-bidi: -webkit-isolate;
+}
+.reset-this bdo {
+  unicode-bidi: bidi-override;
+}
+.reset-this ol li{
+    list-style-type: decimal;
+}

--- a/src/pages/MaterialPage/reset-this.css
+++ b/src/pages/MaterialPage/reset-this.css
@@ -1078,4 +1078,5 @@
 
 .reset-this pre {
     background: #F8F8F8;
+    padding: .5rem;
 }

--- a/src/pages/MaterialPage/style.css
+++ b/src/pages/MaterialPage/style.css
@@ -28,6 +28,14 @@
     margin: 30px 0 20px;
 }
 
+#main-material .padding-top-2 {
+    padding-top: 2rem;
+}
+
+#main-material .grow {
+    flex-grow: 1
+}
+
 #main-material hr {
 	border: none;
 	width: 100%;
@@ -61,7 +69,26 @@
     text-align: left;
 }
 
-#main-material .list-group-flush .list-group-item+.list-group-item.active+{
-    border-color: rgba(0,0,0,.125);
-    background-color: var(--color-gray-1);
+#main-material .list-group {
+    border: 1px solid rgba(0,0,0,.125);
+    border-top-width: 0;
+}
+
+.cont {
+    margin-right: 10%;
+    margin-left: 10%;
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+#main-material .list-group-item {
+    margin-bottom: 0;
+    border: 0px solid rgba(0,0,0,.125);
+    border-top-width: 1px;
+}
+
+#material-links * {
+    background-color: rgba(255, 255, 255, .4);
 }

--- a/src/pages/MaterialPage/style.css
+++ b/src/pages/MaterialPage/style.css
@@ -92,3 +92,7 @@
 #material-links * {
     background-color: rgba(255, 255, 255, .4);
 }
+
+h1, h2, h3, h4, h5, h6 {
+    overflow: hidden;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -14,10 +14,9 @@
 	--color-gray-2: #e4e3d8;
 }
 
-* {
+body {
 	padding: 0;
 	margin: 0;
-	box-sizing: border-box;
-	font-family: 'Open Sans', 'Roboto', Arial, sans-serif;
+	box-sizing: border-box;	
 	overflow-x: hidden;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,11 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
+bail@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
+  integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -2538,6 +2543,21 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2689,6 +2709,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collapse-white-space@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3501,7 +3526,7 @@ dom-helpers@^5.0.1, dom-helpers@^5.1.0, dom-helpers@^5.1.2:
     "@babel/runtime" "^7.6.3"
     csstype "^2.6.7"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
   integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
@@ -3538,6 +3563,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0, domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -3553,6 +3585,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.0.0.tgz#15b8278e37bfa8468d157478c58c367718133c08"
+  integrity sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-prop@^4.1.1:
   version "4.2.0"
@@ -4093,7 +4134,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4846,6 +4887,16 @@ html-minifier@^3.5.20:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
+html-to-react@^1.3.4:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.2.tgz#7b628ab56cd63a52f2d0b79d0fa838a51f088a57"
+  integrity sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==
+  dependencies:
+    domhandler "^3.0"
+    htmlparser2 "^4.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 html-webpack-plugin@4.0.0-beta.5:
   version "4.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz#2c53083c1151bfec20479b1f8aaf0039e77b5513"
@@ -4869,6 +4920,16 @@ htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -5064,7 +5125,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5186,6 +5247,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arguments@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
@@ -5208,7 +5282,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.5:
+is-buffer@^1.0.2, is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -5255,6 +5329,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -5332,6 +5411,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -5363,7 +5447,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -5426,10 +5510,20 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-whitespace-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
+  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-word-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
+  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -6241,6 +6335,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -6351,6 +6450,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
+  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6359,6 +6463,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -7274,6 +7385,18 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -8381,6 +8504,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -8504,10 +8632,29 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
+react-is@^16.8.6:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
+  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-overlays@^2.1.0:
   version "2.1.0"
@@ -8805,6 +8952,27 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -8826,10 +8994,15 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-promise-core@1.1.3:
   version "1.1.3"
@@ -9531,6 +9704,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
+state-toggle@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
+  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -10005,6 +10183,21 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
+  integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+trough@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
+  integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
+
 ts-pnp@1.1.5, ts-pnp@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
@@ -10100,6 +10293,14 @@ uncontrollable@^7.0.0:
     invariant "^2.2.4"
     react-lifecycles-compat "^3.0.4"
 
+unherit@^1.0.4:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
+  integrity sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==
+  dependencies:
+    inherits "^2.0.0"
+    xtend "^4.0.0"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -10122,6 +10323,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -10156,6 +10369,42 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -10310,6 +10559,28 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -10763,6 +11034,11 @@ ws@^6.1.2, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -10773,7 +11049,7 @@ xmlchars@^2.1.1:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
#### What is the purpose of this pull request

This pull request adds markdown lessons to route `/Material/Aula/<lesson-name>`, which is rendered by LessonPage component, and links to the lessons in MaterialPage. The markdowns are transformed to HTML by the react-markdown library, see https://github.com/rexxars/react-markdown. All the markdown files are from GEMA github: https://github.com/icmcgema/gema

#### What was changed

- Create `LessonPage.js` component inside `src/pages/MaterialPage`
- Create `CodeBlock.js` component at same path to be a markdown renderer for highlighting markdown code
- Create `reset-this.css` at same path for reseting bootstrap rules
- Add markdown files in folder `lessons` at same path
- Add route to lessons in `index.js`
- Add links to lessons in MaterialPage component